### PR TITLE
feat: 메뉴 정보 및 상태 수정 API 구현

### DIFF
--- a/src/main/java/com/sparta/bapzip/menu/application/MenuServiceV1.java
+++ b/src/main/java/com/sparta/bapzip/menu/application/MenuServiceV1.java
@@ -5,6 +5,7 @@ import com.sparta.bapzip.global.exception.GlobalException;
 import com.sparta.bapzip.menu.domain.entity.MenuEntity;
 import com.sparta.bapzip.menu.domain.repository.MenuRepository;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuCreateRequest;
+import com.sparta.bapzip.menu.presentation.dto.request.MenuUpdateRequest;
 import com.sparta.bapzip.menu.presentation.dto.response.MenuCreateResponse;
 import com.sparta.bapzip.menu.presentation.dto.response.MenuDetailResponse;
 import com.sparta.bapzip.shop.application.ShopServiceV1;
@@ -42,6 +43,26 @@ public class MenuServiceV1 {
     // 메뉴 상세 조회
     public MenuDetailResponse getMenuDetail(UUID menuId) {
         MenuEntity menu = getMenuById(menuId);
+        return MenuDetailResponse.from(menu);
+    }
+
+    // 메뉴 정보 수정
+    // todo: (+) 의도한 공백 값 처리 로직 추가
+    @Transactional
+    public MenuDetailResponse updateMenu(UUID menuId, MenuUpdateRequest request) {
+
+        MenuEntity menu = getMenuById(menuId);
+
+        if (request.name() != null && !request.name().isBlank()) {
+            menu.updateName(request.name());
+        }
+        if (request.content() != null && !request.content().isBlank()) {
+            menu.updateContent(request.content());
+        }
+        if (request.price() != null) {
+            menu.updatePrice(request.price());
+        }
+
         return MenuDetailResponse.from(menu);
     }
 

--- a/src/main/java/com/sparta/bapzip/menu/application/MenuServiceV1.java
+++ b/src/main/java/com/sparta/bapzip/menu/application/MenuServiceV1.java
@@ -5,6 +5,7 @@ import com.sparta.bapzip.global.exception.GlobalException;
 import com.sparta.bapzip.menu.domain.entity.MenuEntity;
 import com.sparta.bapzip.menu.domain.repository.MenuRepository;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuCreateRequest;
+import com.sparta.bapzip.menu.presentation.dto.request.MenuStatusUpdateRequest;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuUpdateRequest;
 import com.sparta.bapzip.menu.presentation.dto.response.MenuCreateResponse;
 import com.sparta.bapzip.menu.presentation.dto.response.MenuDetailResponse;
@@ -63,6 +64,14 @@ public class MenuServiceV1 {
             menu.updatePrice(request.price());
         }
 
+        return MenuDetailResponse.from(menu);
+    }
+
+    // 메뉴 상태 수정 - AVAILABLE, SOLD_OUT
+    @Transactional
+    public MenuDetailResponse updateMenuStatus(UUID menuId, MenuStatusUpdateRequest request){
+        MenuEntity menu = getMenuById(menuId);
+        menu.updateStatus(request.status());
         return MenuDetailResponse.from(menu);
     }
 

--- a/src/main/java/com/sparta/bapzip/menu/domain/entity/MenuEntity.java
+++ b/src/main/java/com/sparta/bapzip/menu/domain/entity/MenuEntity.java
@@ -57,4 +57,21 @@ public class MenuEntity {
                 .build();
     }
 
+    /**
+     * update Filed
+     */
+    public void updateName(String name) {
+        this.name = name;
+    }
+    public void updateContent(String content) {
+        this.content = content;
+    }
+    public void updatePrice(int price) {
+        this.price = price;
+    }
+    public void updateStatus(MenuStatus status) {
+        this.status = status;
+    }
+
+
 }

--- a/src/main/java/com/sparta/bapzip/menu/presentation/controller/MenuControllerV1.java
+++ b/src/main/java/com/sparta/bapzip/menu/presentation/controller/MenuControllerV1.java
@@ -2,6 +2,7 @@ package com.sparta.bapzip.menu.presentation.controller;
 
 import com.sparta.bapzip.menu.application.MenuServiceV1;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuCreateRequest;
+import com.sparta.bapzip.menu.presentation.dto.request.MenuUpdateRequest;
 import com.sparta.bapzip.menu.presentation.dto.response.MenuCreateResponse;
 import com.sparta.bapzip.menu.presentation.dto.response.MenuDetailResponse;
 import jakarta.validation.Valid;
@@ -26,7 +27,7 @@ public class MenuControllerV1 {
     @PostMapping
     public ResponseEntity<MenuCreateResponse> createMenu(@RequestBody @Valid MenuCreateRequest request){
         MenuCreateResponse menuCreateResponse = menuService.createMenu(request);
-        return ResponseEntity.ok().body(menuCreateResponse);
+        return ResponseEntity.ok(menuCreateResponse);
     }
 
     /**
@@ -35,6 +36,16 @@ public class MenuControllerV1 {
     @GetMapping("/{menuId}")
     public ResponseEntity<MenuDetailResponse> getMenuById(@PathVariable UUID menuId){
         MenuDetailResponse menuDetailResponse = menuService.getMenuDetail(menuId);
-        return ResponseEntity.ok().body(menuDetailResponse);
+        return ResponseEntity.ok(menuDetailResponse);
+    }
+
+    /**
+     * 메뉴 정보 수정
+     */
+    @PatchMapping("/{menuId}")
+    public ResponseEntity<MenuDetailResponse> updateMenu(@PathVariable UUID menuId,
+                                                         @RequestBody @Valid MenuUpdateRequest request){
+        MenuDetailResponse menuDetailResponse = menuService.updateMenu(menuId, request);
+        return ResponseEntity.ok(menuDetailResponse);
     }
 }

--- a/src/main/java/com/sparta/bapzip/menu/presentation/controller/MenuControllerV1.java
+++ b/src/main/java/com/sparta/bapzip/menu/presentation/controller/MenuControllerV1.java
@@ -2,6 +2,7 @@ package com.sparta.bapzip.menu.presentation.controller;
 
 import com.sparta.bapzip.menu.application.MenuServiceV1;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuCreateRequest;
+import com.sparta.bapzip.menu.presentation.dto.request.MenuStatusUpdateRequest;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuUpdateRequest;
 import com.sparta.bapzip.menu.presentation.dto.response.MenuCreateResponse;
 import com.sparta.bapzip.menu.presentation.dto.response.MenuDetailResponse;
@@ -47,5 +48,15 @@ public class MenuControllerV1 {
                                                          @RequestBody @Valid MenuUpdateRequest request){
         MenuDetailResponse menuDetailResponse = menuService.updateMenu(menuId, request);
         return ResponseEntity.ok(menuDetailResponse);
+    }
+
+    /**
+     * 메뉴 상태 수정
+     */
+    @PatchMapping("/{menuId}/status")
+    public ResponseEntity<MenuDetailResponse> updateMenuStatus(@PathVariable UUID menuId,
+                                                               @RequestBody @Valid MenuStatusUpdateRequest request){
+        MenuDetailResponse MenuDetailResponse = menuService.updateMenuStatus(menuId, request);
+        return ResponseEntity.ok(MenuDetailResponse);
     }
 }

--- a/src/main/java/com/sparta/bapzip/menu/presentation/dto/request/MenuStatusUpdateRequest.java
+++ b/src/main/java/com/sparta/bapzip/menu/presentation/dto/request/MenuStatusUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.sparta.bapzip.menu.presentation.dto.request;
+
+import com.sparta.bapzip.menu.domain.enums.MenuStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record MenuStatusUpdateRequest(
+        @NotNull(message = "메뉴 상태를 입력해주세요")
+        MenuStatus status
+) {
+}

--- a/src/main/java/com/sparta/bapzip/menu/presentation/dto/request/MenuUpdateRequest.java
+++ b/src/main/java/com/sparta/bapzip/menu/presentation/dto/request/MenuUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.sparta.bapzip.menu.presentation.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+
+public record MenuUpdateRequest(
+        String name,
+
+        @Size(max = 255, message = "내용은 최대 255자 이내로 작성해야 합니다.")
+        String content,
+
+        // update Integer => null값 허용 (PATCH)
+        @Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
+        @Max(value = 9999999, message = "메뉴 가격의 허용 범위를 초과했습니다.")
+        Integer price
+) {
+}


### PR DESCRIPTION
## 📒 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #30 

## 📒 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
메뉴 정보, 상태 수정 API 구현
- 정보, 상태 수정 res dto -> `MenuDetailResponse` 사용
- 개발 편의성을 위해 **SecurityConfig** 파일에
` .requestMatchers("/v1/menus/**").permitAll()` 을 추가하여 개발하였습니다. 이 점 참고해주세요
- 👉🏻 인증, 권한 관련은 한 번에 추가 예정입니다.

## 📒 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="696" height="692" alt="스크린샷 2025-10-08 211448" src="https://github.com/user-attachments/assets/5f075f2d-a931-4e13-8759-dac4a64023ce" />
<img width="675" height="698" alt="스크린샷 2025-10-08 211643" src="https://github.com/user-attachments/assets/1de96145-ae60-4bf5-a434-0cabb36d498c" />
<img width="721" height="701" alt="스크린샷 2025-10-08 211703" src="https://github.com/user-attachments/assets/dc4a270b-099f-432c-928f-06e20eec3f42" />
<img width="680" height="648" alt="스크린샷 2025-10-08 212009" src="https://github.com/user-attachments/assets/c227d47b-da05-4a8f-b29d-dcb070198d36" />
<img width="755" height="651" alt="스크린샷 2025-10-08 212606" src="https://github.com/user-attachments/assets/f4457e6a-88bf-4244-aaa4-457189c2738f" />



## 📒 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
