### PR TITLE
feat: 전체유저 조회 API 구현

### DIFF
--- a/src/main/java/com/sparta/bapzip/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/sparta/bapzip/global/infrastructure/config/security/SecurityConfig.java
@@ -67,6 +67,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests((authorizeHttpRequests) ->
                 authorizeHttpRequests
                         .requestMatchers("/v1/users/signup", "/v1/users/login").permitAll()
+                        .requestMatchers("/v1/users").hasAnyRole("MASTER", "MANAGER")
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );
 

--- a/src/main/java/com/sparta/bapzip/user/application/UserServiceV1.java
+++ b/src/main/java/com/sparta/bapzip/user/application/UserServiceV1.java
@@ -1,14 +1,19 @@
 package com.sparta.bapzip.user.application;
 
 import com.sparta.bapzip.global.exception.ErrorCode;
+import com.sparta.bapzip.user.application.dto.response.UserResponseDto;
 import com.sparta.bapzip.user.application.excpetion.DuplicateUserException;
 import com.sparta.bapzip.user.application.excpetion.UnauthorizedUserException;
 import com.sparta.bapzip.user.domain.entity.UserEntity;
 import com.sparta.bapzip.user.domain.enums.UserRoleEnum;
 import com.sparta.bapzip.user.domain.repository.UserRepository;
-import com.sparta.bapzip.user.presentation.dto.request.SignupRequestDto;
-import com.sparta.bapzip.user.presentation.dto.response.SignupResponseDto;
+import com.sparta.bapzip.user.application.dto.request.SignupRequestDto;
+import com.sparta.bapzip.user.application.dto.response.SignupResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -35,5 +40,23 @@ public class UserServiceV1 {
         UserEntity user = UserEntity.create(requestDto, passwordEncoder.encode(requestDto.getPassword()));
         UserEntity saveUser = userRepository.save(user);
         return SignupResponseDto.of(saveUser);
+    }
+
+    public Page<UserResponseDto> getUserList(int page, int size, String sortBy, boolean isAsc, UserEntity user) {
+        UserRoleEnum role = user.getRole();
+        if (!(role.equals(UserRoleEnum.MANAGER) || role.equals(UserRoleEnum.MASTER))) {
+            throw new UnauthorizedUserException(ErrorCode.UNAUTHORIZED_USER_EXCEPTION);
+        }
+
+        if(size != 10 && size != 30 && size != 50) {
+            size = 10;
+        }
+
+        Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Sort sort = Sort.by(direction, sortBy);
+        Pageable pageable = PageRequest.of(page, size, sort);
+
+        Page<UserEntity> userList = userRepository.findAll(pageable);
+        return userList.map(UserResponseDto::of);
     }
 }

--- a/src/main/java/com/sparta/bapzip/user/application/UserServiceV1.java
+++ b/src/main/java/com/sparta/bapzip/user/application/UserServiceV1.java
@@ -42,12 +42,7 @@ public class UserServiceV1 {
         return SignupResponseDto.of(saveUser);
     }
 
-    public Page<UserResponseDto> getUserList(int page, int size, String sortBy, boolean isAsc, UserEntity user) {
-        UserRoleEnum role = user.getRole();
-        if (!(role.equals(UserRoleEnum.MANAGER) || role.equals(UserRoleEnum.MASTER))) {
-            throw new UnauthorizedUserException(ErrorCode.UNAUTHORIZED_USER_EXCEPTION);
-        }
-
+    public Page<UserResponseDto> getUserList(int page, int size, String sortBy, boolean isAsc) {
         if(size != 10 && size != 30 && size != 50) {
             size = 10;
         }

--- a/src/main/java/com/sparta/bapzip/user/application/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/sparta/bapzip/user/application/dto/request/LoginRequestDto.java
@@ -1,6 +1,5 @@
-package com.sparta.bapzip.user.presentation.dto.request;
+package com.sparta.bapzip.user.application.dto.request;
 
-import com.sparta.bapzip.user.domain.enums.UserRoleEnum;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -8,18 +7,12 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class SignupRequestDto {
+public class LoginRequestDto {
 
     @NotBlank
     @Email
     private String email;
 
     @NotBlank
-    private String name;
-
-    @NotBlank
     private String password;
-
-    @NotBlank
-    private UserRoleEnum role;
 }

--- a/src/main/java/com/sparta/bapzip/user/application/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/sparta/bapzip/user/application/dto/request/SignupRequestDto.java
@@ -1,5 +1,6 @@
-package com.sparta.bapzip.user.presentation.dto.request;
+package com.sparta.bapzip.user.application.dto.request;
 
+import com.sparta.bapzip.user.domain.enums.UserRoleEnum;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -7,12 +8,18 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class LoginRequestDto {
+public class SignupRequestDto {
 
     @NotBlank
     @Email
     private String email;
 
     @NotBlank
+    private String name;
+
+    @NotBlank
     private String password;
+
+    @NotBlank
+    private UserRoleEnum role;
 }

--- a/src/main/java/com/sparta/bapzip/user/application/dto/response/SignupResponseDto.java
+++ b/src/main/java/com/sparta/bapzip/user/application/dto/response/SignupResponseDto.java
@@ -1,4 +1,4 @@
-package com.sparta.bapzip.user.presentation.dto.response;
+package com.sparta.bapzip.user.application.dto.response;
 
 import com.sparta.bapzip.user.domain.entity.UserEntity;
 import com.sparta.bapzip.user.domain.enums.UserRoleEnum;

--- a/src/main/java/com/sparta/bapzip/user/application/dto/response/UserResponseDto.java
+++ b/src/main/java/com/sparta/bapzip/user/application/dto/response/UserResponseDto.java
@@ -1,0 +1,36 @@
+package com.sparta.bapzip.user.application.dto.response;
+
+import com.sparta.bapzip.user.domain.entity.UserEntity;
+import com.sparta.bapzip.user.domain.enums.UserRoleEnum;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserResponseDto {
+
+    private Long id;
+
+    private String name;
+
+    private String email;
+
+    private UserRoleEnum role;
+
+    private LocalDateTime createdAt;
+
+    private boolean isDeleted;
+
+    public static UserResponseDto of(UserEntity user) {
+        return UserResponseDto.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .role(user.getRole())
+                .createdAt(user.getCreatedAt())
+                .isDeleted(user.getIsDeleted())
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/bapzip/user/domain/entity/UserEntity.java
+++ b/src/main/java/com/sparta/bapzip/user/domain/entity/UserEntity.java
@@ -2,7 +2,7 @@ package com.sparta.bapzip.user.domain.entity;
 
 import com.sparta.bapzip.global.common.BaseEntity;
 import com.sparta.bapzip.user.domain.enums.UserRoleEnum;
-import com.sparta.bapzip.user.presentation.dto.request.SignupRequestDto;
+import com.sparta.bapzip.user.application.dto.request.SignupRequestDto;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/sparta/bapzip/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/sparta/bapzip/user/domain/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package com.sparta.bapzip.user.domain.repository;
 
 import com.sparta.bapzip.user.domain.entity.UserEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
@@ -11,4 +13,6 @@ public interface UserRepository {
     Optional<UserEntity> findByEmail(String email);
 
     UserEntity save(UserEntity user);
+
+    Page<UserEntity> findAll(Pageable pageable);
 }

--- a/src/main/java/com/sparta/bapzip/user/infrastructure/repository/UserJpaRepository.java
+++ b/src/main/java/com/sparta/bapzip/user/infrastructure/repository/UserJpaRepository.java
@@ -1,6 +1,8 @@
 package com.sparta.bapzip.user.infrastructure.repository;
 
 import com.sparta.bapzip.user.domain.entity.UserEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +10,6 @@ import java.util.Optional;
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
 
     Optional<UserEntity> findByEmail(String email);
+
+    Page<UserEntity> findAll(Pageable pageable);
 }

--- a/src/main/java/com/sparta/bapzip/user/infrastructure/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/sparta/bapzip/user/infrastructure/repository/UserRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.sparta.bapzip.user.infrastructure.repository;
 import com.sparta.bapzip.user.domain.entity.UserEntity;
 import com.sparta.bapzip.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -26,5 +28,10 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public UserEntity save(UserEntity user) {
         return userJpaRepository.save(user);
+    }
+
+    @Override
+    public Page<UserEntity> findAll(Pageable pageable) {
+        return userJpaRepository.findAll(pageable);
     }
 }

--- a/src/main/java/com/sparta/bapzip/user/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/bapzip/user/jwt/JwtAuthenticationFilter.java
@@ -4,7 +4,7 @@ package com.sparta.bapzip.user.jwt;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.bapzip.user.domain.entity.UserDetailsImpl;
 import com.sparta.bapzip.user.domain.entity.UserEntity;
-import com.sparta.bapzip.user.presentation.dto.request.LoginRequestDto;
+import com.sparta.bapzip.user.application.dto.request.LoginRequestDto;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/sparta/bapzip/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/sparta/bapzip/user/presentation/controller/UserControllerV1.java
@@ -1,14 +1,11 @@
 package com.sparta.bapzip.user.presentation.controller;
 
 import com.sparta.bapzip.user.application.UserServiceV1;
-import com.sparta.bapzip.user.application.dto.response.UserResponseDto;
-import com.sparta.bapzip.user.domain.entity.UserDetailsImpl;
-import com.sparta.bapzip.user.domain.entity.UserEntity;
 import com.sparta.bapzip.user.application.dto.request.SignupRequestDto;
 import com.sparta.bapzip.user.application.dto.response.SignupResponseDto;
+import com.sparta.bapzip.user.application.dto.response.UserResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -27,9 +24,8 @@ public class UserControllerV1 {
     public Page<UserResponseDto> getUserList(@RequestParam("page") int page,
                                              @RequestParam("size") int size,
                                              @RequestParam("sortBy") String sortBy,
-                                             @RequestParam("isAsc") boolean isAsc,
-                                             @AuthenticationPrincipal UserDetailsImpl userDetails) {
+                                             @RequestParam("isAsc") boolean isAsc) {
 
-        return userServiceV1.getUserList(page - 1, size, sortBy, isAsc, userDetails.getUser());
+        return userServiceV1.getUserList(page - 1, size, sortBy, isAsc);
     }
 }

--- a/src/main/java/com/sparta/bapzip/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/sparta/bapzip/user/presentation/controller/UserControllerV1.java
@@ -1,13 +1,15 @@
 package com.sparta.bapzip.user.presentation.controller;
 
 import com.sparta.bapzip.user.application.UserServiceV1;
-import com.sparta.bapzip.user.presentation.dto.request.SignupRequestDto;
-import com.sparta.bapzip.user.presentation.dto.response.SignupResponseDto;
+import com.sparta.bapzip.user.application.dto.response.UserResponseDto;
+import com.sparta.bapzip.user.domain.entity.UserDetailsImpl;
+import com.sparta.bapzip.user.domain.entity.UserEntity;
+import com.sparta.bapzip.user.application.dto.request.SignupRequestDto;
+import com.sparta.bapzip.user.application.dto.response.SignupResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Page;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,5 +21,15 @@ public class UserControllerV1 {
     @PostMapping("/signup")
     public SignupResponseDto signup(@RequestBody SignupRequestDto requestDto) {
         return userServiceV1.signup(requestDto);
+    }
+
+    @GetMapping
+    public Page<UserResponseDto> getUserList(@RequestParam("page") int page,
+                                             @RequestParam("size") int size,
+                                             @RequestParam("sortBy") String sortBy,
+                                             @RequestParam("isAsc") boolean isAsc,
+                                             @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        return userServiceV1.getUserList(page - 1, size, sortBy, isAsc, userDetails.getUser());
     }
 }


### PR DESCRIPTION
## 📒 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #52 

## 📒 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
MASTER와 MANEGER의 전체 유저 조회 기능 구현
security 설정에서 마스터와 매니저 롤인 유저만 API에 접근할 수 있도록 구현

## 📒 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="946" height="1057" alt="스크린샷 2025-10-09 오후 3 08 46" src="https://github.com/user-attachments/assets/644c3b89-7b35-43ac-8a75-01ffff4cbb3a" />


## 📒 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->

