### PR TITLE
feat: 메뉴 검색 API 구현

### DIFF
--- a/src/main/java/com/sparta/bapzip/menu/application/MenuServiceV1.java
+++ b/src/main/java/com/sparta/bapzip/menu/application/MenuServiceV1.java
@@ -88,7 +88,7 @@ public class MenuServiceV1 {
      * @param page     페이지 번호 (0부터 시작)
      * @param size     한 페이지에 가져올 메뉴 개수 (유효 size: 10, 30, 50; 이외 값 입력시 10으로 고정)
      * @param sortBy   정렬할 필드명 (ex) "createdAt", "price")
-     * @param isAsc    정렬 방향 (default true: 오름차순, false: 내림차순)
+     * @param isAsc    정렬 방향 (true: 오름차순, false: 내림차순(default))
      * @return         페이징된 메뉴 DTO Page<MenuSearchResponse>
      */
     public Page<MenuSearchResponse> searchMenus(String keyword, int page, int size, String sortBy, boolean isAsc) {

--- a/src/main/java/com/sparta/bapzip/menu/application/MenuServiceV1.java
+++ b/src/main/java/com/sparta/bapzip/menu/application/MenuServiceV1.java
@@ -5,6 +5,7 @@ import com.sparta.bapzip.global.exception.GlobalException;
 import com.sparta.bapzip.menu.domain.entity.MenuEntity;
 import com.sparta.bapzip.menu.domain.repository.MenuRepository;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuCreateRequest;
+import com.sparta.bapzip.menu.presentation.dto.request.MenuSearchRequest;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuStatusUpdateRequest;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuUpdateRequest;
 import com.sparta.bapzip.menu.presentation.dto.response.MenuCreateResponse;
@@ -13,6 +14,10 @@ import com.sparta.bapzip.menu.presentation.dto.response.MenuSearchResponse;
 import com.sparta.bapzip.shop.application.ShopServiceV1;
 import com.sparta.bapzip.shop.domain.entity.ShopEntity;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -77,6 +82,31 @@ public class MenuServiceV1 {
     }
 
 
+    /**
+     * 메뉴 이름 기반 조회 (search)
+     * @param request keyword 검색할 메뉴 이름 -> 확장성을 위해 keyword라 명시
+     * @param page,size,sort 페이징 및 정렬
+     * @return 페이징 메뉴 DTO
+     * validatedSize: page 10,30,50 size
+     */
+    public Page<MenuSearchResponse> searchMenus(MenuSearchRequest request, int page, int size, String sort) {
+
+        // size 10, 30, 50 유효, 아닐 시 10 고정
+        int validatedSize = List.of(10, 30, 50).contains(size) ? size : 10;
+
+        // sort (정렬) param
+        String[] sortParams = sort.split(",");
+        String sortBy = sortParams[0];
+        Sort.Direction direction = "asc".equalsIgnoreCase(sortParams[1]) ? Sort.Direction.ASC : Sort.Direction.DESC;
+
+        Pageable pageable = PageRequest.of(page, validatedSize, Sort.by(direction, sortBy));
+
+        Page<MenuEntity> menuPage = menuRepository.findByNameContaining(request.keyword(), pageable);
+        return menuPage.map(MenuSearchResponse::from);
+    }
+
+
+
     // 메뉴 전체 조회
     public List<MenuSearchResponse> getAllMenus() {
         List<MenuEntity> menus = menuRepository.findAll();
@@ -84,7 +114,6 @@ public class MenuServiceV1 {
                 .map(MenuSearchResponse::from)
                 .toList(); // DTO -> List 반환
     }
-
 
     /**
      * 엔티티 조회 헬퍼

--- a/src/main/java/com/sparta/bapzip/menu/application/MenuServiceV1.java
+++ b/src/main/java/com/sparta/bapzip/menu/application/MenuServiceV1.java
@@ -83,25 +83,25 @@ public class MenuServiceV1 {
 
 
     /**
-     * 메뉴 이름 기반 조회 (search)
-     * @param request keyword 검색할 메뉴 이름 -> 확장성을 위해 keyword라 명시
-     * @param page,size,sort 페이징 및 정렬
-     * @return 페이징 메뉴 DTO
-     * validatedSize: page 10,30,50 size
+     * 메뉴 이름 기반 조회 (검색)
+     *
+     * @param keyword  검색어
+     * @param page     페이지 번호 (0부터 시작)
+     * @param size     한 페이지에 가져올 메뉴 개수 (유효 size: 10, 30, 50; 이외 값 입력시 10으로 고정)
+     * @param sortBy   정렬할 필드명 (ex) "createdAt", "price")
+     * @param isAsc    정렬 방향 (default true: 오름차순, false: 내림차순)
+     * @return         페이징된 메뉴 DTO Page<MenuSearchResponse>
      */
-    public Page<MenuSearchResponse> searchMenus(MenuSearchRequest request, int page, int size, String sort) {
+    public Page<MenuSearchResponse> searchMenus(String keyword, int page, int size, String sortBy, boolean isAsc) {
 
         // size 10, 30, 50 유효, 아닐 시 10 고정
         int validatedSize = List.of(10, 30, 50).contains(size) ? size : 10;
 
         // sort (정렬) param
-        String[] sortParams = sort.split(",");
-        String sortBy = sortParams[0];
-        Sort.Direction direction = "asc".equalsIgnoreCase(sortParams[1]) ? Sort.Direction.ASC : Sort.Direction.DESC;
-
+        Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
         Pageable pageable = PageRequest.of(page, validatedSize, Sort.by(direction, sortBy));
 
-        Page<MenuEntity> menuPage = menuRepository.findByNameContaining(request.keyword(), pageable);
+        Page<MenuEntity> menuPage = menuRepository.findByNameContaining(keyword, pageable);
         return menuPage.map(MenuSearchResponse::from);
     }
 

--- a/src/main/java/com/sparta/bapzip/menu/application/MenuServiceV1.java
+++ b/src/main/java/com/sparta/bapzip/menu/application/MenuServiceV1.java
@@ -5,7 +5,6 @@ import com.sparta.bapzip.global.exception.GlobalException;
 import com.sparta.bapzip.menu.domain.entity.MenuEntity;
 import com.sparta.bapzip.menu.domain.repository.MenuRepository;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuCreateRequest;
-import com.sparta.bapzip.menu.presentation.dto.request.MenuSearchRequest;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuStatusUpdateRequest;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuUpdateRequest;
 import com.sparta.bapzip.menu.presentation.dto.response.MenuCreateResponse;

--- a/src/main/java/com/sparta/bapzip/menu/application/MenuServiceV1.java
+++ b/src/main/java/com/sparta/bapzip/menu/application/MenuServiceV1.java
@@ -9,6 +9,7 @@ import com.sparta.bapzip.menu.presentation.dto.request.MenuStatusUpdateRequest;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuUpdateRequest;
 import com.sparta.bapzip.menu.presentation.dto.response.MenuCreateResponse;
 import com.sparta.bapzip.menu.presentation.dto.response.MenuDetailResponse;
+import com.sparta.bapzip.menu.presentation.dto.response.MenuSearchResponse;
 import com.sparta.bapzip.shop.application.ShopServiceV1;
 import com.sparta.bapzip.shop.domain.entity.ShopEntity;
 import lombok.RequiredArgsConstructor;
@@ -76,7 +77,18 @@ public class MenuServiceV1 {
     }
 
 
-    // --------------------- Entity 조회 메서드 -------------------------- //
+    // 메뉴 전체 조회
+    public List<MenuSearchResponse> getAllMenus() {
+        List<MenuEntity> menus = menuRepository.findAll();
+        return menus.stream()
+                .map(MenuSearchResponse::from)
+                .toList(); // DTO -> List 반환
+    }
+
+
+    /**
+     * 엔티티 조회 헬퍼
+     */
 
     // 메뉴 엔티티 조회
     public MenuEntity getMenuById(UUID menuId) {

--- a/src/main/java/com/sparta/bapzip/menu/domain/entity/MenuEntity.java
+++ b/src/main/java/com/sparta/bapzip/menu/domain/entity/MenuEntity.java
@@ -1,6 +1,7 @@
 package com.sparta.bapzip.menu.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.sparta.bapzip.global.common.BaseEntity;
 import com.sparta.bapzip.menu.domain.enums.MenuStatus;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuCreateRequest;
 import com.sparta.bapzip.ordermenu.domain.entity.OrderMenuEntity;
@@ -18,7 +19,7 @@ import java.util.UUID;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class MenuEntity {
+public class MenuEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/src/main/java/com/sparta/bapzip/menu/domain/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/bapzip/menu/domain/repository/MenuRepository.java
@@ -1,6 +1,8 @@
 package com.sparta.bapzip.menu.domain.repository;
 
 import com.sparta.bapzip.menu.domain.entity.MenuEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,6 +15,8 @@ public interface MenuRepository {
     Optional<MenuEntity> findById(UUID id);
 
     List<MenuEntity> findAll();
+
+    Page<MenuEntity> findByNameContaining(String keyword, Pageable pageable);
 
     List<MenuEntity> findAllByIdIn(List<UUID> ids);
 

--- a/src/main/java/com/sparta/bapzip/menu/domain/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/bapzip/menu/domain/repository/MenuRepository.java
@@ -12,6 +12,8 @@ public interface MenuRepository {
 
     Optional<MenuEntity> findById(UUID id);
 
+    List<MenuEntity> findAll();
+
     List<MenuEntity> findAllByIdIn(List<UUID> ids);
 
 }

--- a/src/main/java/com/sparta/bapzip/menu/infrastructure/repository/MenuJpaRepository.java
+++ b/src/main/java/com/sparta/bapzip/menu/infrastructure/repository/MenuJpaRepository.java
@@ -1,6 +1,8 @@
 package com.sparta.bapzip.menu.infrastructure.repository;
 
 import com.sparta.bapzip.menu.domain.entity.MenuEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,4 +11,5 @@ import java.util.UUID;
 public interface MenuJpaRepository extends JpaRepository<MenuEntity, UUID> {
 
     List<MenuEntity> findAllByIdIn(List<UUID> ids);
+    Page<MenuEntity> findByNameContaining(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/sparta/bapzip/menu/infrastructure/repository/MenuJpaRepository.java
+++ b/src/main/java/com/sparta/bapzip/menu/infrastructure/repository/MenuJpaRepository.java
@@ -3,7 +3,9 @@ package com.sparta.bapzip.menu.infrastructure.repository;
 import com.sparta.bapzip.menu.domain.entity.MenuEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.UUID;
@@ -11,5 +13,7 @@ import java.util.UUID;
 public interface MenuJpaRepository extends JpaRepository<MenuEntity, UUID> {
 
     List<MenuEntity> findAllByIdIn(List<UUID> ids);
+
+    @EntityGraph(attributePaths = {"shop"})
     Page<MenuEntity> findByNameContaining(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/sparta/bapzip/menu/infrastructure/repository/MenuRepositoryImpl.java
+++ b/src/main/java/com/sparta/bapzip/menu/infrastructure/repository/MenuRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.sparta.bapzip.menu.infrastructure.repository;
 import com.sparta.bapzip.menu.domain.entity.MenuEntity;
 import com.sparta.bapzip.menu.domain.repository.MenuRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -27,7 +29,13 @@ public class MenuRepositoryImpl implements MenuRepository {
         return menuJpaRepository.findById(id);
     }
 
-    // 메뉴 전체 조회
+    // 메뉴 이름 기반 검색 조회
+    @Override
+    public Page<MenuEntity> findByNameContaining(String keyword, Pageable pageable) {
+        return menuJpaRepository.findByNameContaining(keyword, pageable);
+    }
+
+    // 메뉴 전체 조회 todo 내부용 구분
     @Override
     public List<MenuEntity> findAll(){
         return menuJpaRepository.findAll();

--- a/src/main/java/com/sparta/bapzip/menu/infrastructure/repository/MenuRepositoryImpl.java
+++ b/src/main/java/com/sparta/bapzip/menu/infrastructure/repository/MenuRepositoryImpl.java
@@ -27,6 +27,12 @@ public class MenuRepositoryImpl implements MenuRepository {
         return menuJpaRepository.findById(id);
     }
 
+    // 메뉴 전체 조회
+    @Override
+    public List<MenuEntity> findAll(){
+        return menuJpaRepository.findAll();
+    }
+
     // 메뉴 List 반환 메서드
     @Override
     public List<MenuEntity> findAllByIdIn(List<UUID> ids) {

--- a/src/main/java/com/sparta/bapzip/menu/presentation/controller/MenuControllerV1.java
+++ b/src/main/java/com/sparta/bapzip/menu/presentation/controller/MenuControllerV1.java
@@ -6,11 +6,13 @@ import com.sparta.bapzip.menu.presentation.dto.request.MenuStatusUpdateRequest;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuUpdateRequest;
 import com.sparta.bapzip.menu.presentation.dto.response.MenuCreateResponse;
 import com.sparta.bapzip.menu.presentation.dto.response.MenuDetailResponse;
+import com.sparta.bapzip.menu.presentation.dto.response.MenuSearchResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RequiredArgsConstructor
@@ -39,6 +41,16 @@ public class MenuControllerV1 {
         MenuDetailResponse menuDetailResponse = menuService.getMenuDetail(menuId);
         return ResponseEntity.ok(menuDetailResponse);
     }
+
+    /**
+     * 메뉴 전체 조회
+     */
+    @GetMapping
+    public ResponseEntity<List<MenuSearchResponse>> getAllMenus(){
+        List<MenuSearchResponse> menuList = menuService.getAllMenus();
+        return ResponseEntity.ok(menuList);
+    }
+
 
     /**
      * 메뉴 정보 수정

--- a/src/main/java/com/sparta/bapzip/menu/presentation/controller/MenuControllerV1.java
+++ b/src/main/java/com/sparta/bapzip/menu/presentation/controller/MenuControllerV1.java
@@ -52,10 +52,11 @@ public class MenuControllerV1 {
             @Valid @ModelAttribute MenuSearchRequest request,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size,
-            @RequestParam(value = "sort", defaultValue = "createdAt,desc") String sort
+            @RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy,
+            @RequestParam(value = "isAsc", defaultValue = "false") boolean isAsc
     ) {
         // 페이징 검증 service 에서 처리
-        Page<MenuSearchResponse> menuPage = menuService.searchMenus(request, page, size, sort);
+        Page<MenuSearchResponse> menuPage = menuService.searchMenus(request.keyword(), page, size, sortBy, isAsc);
         return ResponseEntity.ok(menuPage);
     }
 

--- a/src/main/java/com/sparta/bapzip/menu/presentation/controller/MenuControllerV1.java
+++ b/src/main/java/com/sparta/bapzip/menu/presentation/controller/MenuControllerV1.java
@@ -2,6 +2,7 @@ package com.sparta.bapzip.menu.presentation.controller;
 
 import com.sparta.bapzip.menu.application.MenuServiceV1;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuCreateRequest;
+import com.sparta.bapzip.menu.presentation.dto.request.MenuSearchRequest;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuStatusUpdateRequest;
 import com.sparta.bapzip.menu.presentation.dto.request.MenuUpdateRequest;
 import com.sparta.bapzip.menu.presentation.dto.response.MenuCreateResponse;
@@ -9,6 +10,7 @@ import com.sparta.bapzip.menu.presentation.dto.response.MenuDetailResponse;
 import com.sparta.bapzip.menu.presentation.dto.response.MenuSearchResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -43,6 +45,21 @@ public class MenuControllerV1 {
     }
 
     /**
+     * 메뉴 검색 조회
+     */
+    @GetMapping("/search")
+    public ResponseEntity<Page<MenuSearchResponse>> searchMenus(
+            @Valid @ModelAttribute MenuSearchRequest request,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam(value = "sort", defaultValue = "createdAt,desc") String sort
+    ) {
+        // 페이징 검증 service 에서 처리
+        Page<MenuSearchResponse> menuPage = menuService.searchMenus(request, page, size, sort);
+        return ResponseEntity.ok(menuPage);
+    }
+
+    /**
      * 메뉴 전체 조회
      */
     @GetMapping
@@ -50,7 +67,6 @@ public class MenuControllerV1 {
         List<MenuSearchResponse> menuList = menuService.getAllMenus();
         return ResponseEntity.ok(menuList);
     }
-
 
     /**
      * 메뉴 정보 수정

--- a/src/main/java/com/sparta/bapzip/menu/presentation/dto/request/MenuSearchRequest.java
+++ b/src/main/java/com/sparta/bapzip/menu/presentation/dto/request/MenuSearchRequest.java
@@ -1,0 +1,9 @@
+package com.sparta.bapzip.menu.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MenuSearchRequest(
+        @NotBlank(message="검색어를 입력해 주세요.")
+        String keyword
+) {
+}

--- a/src/main/java/com/sparta/bapzip/menu/presentation/dto/response/MenuSearchResponse.java
+++ b/src/main/java/com/sparta/bapzip/menu/presentation/dto/response/MenuSearchResponse.java
@@ -1,0 +1,27 @@
+package com.sparta.bapzip.menu.presentation.dto.response;
+
+import com.sparta.bapzip.menu.domain.entity.MenuEntity;
+
+import java.util.UUID;
+
+/**
+ * 배달앱을 참고한 필드
+ * 메뉴 이름, 가격, 가게 이름, 필요 시 상태 + 리뷰 구현 시 가게 평점
+ */
+public record MenuSearchResponse(
+        UUID id,
+        String name,
+        int price,
+        UUID shopId,
+        String shopName
+) {
+    public static MenuSearchResponse from(MenuEntity menu) {
+        return new MenuSearchResponse(
+                menu.getId(),
+                menu.getName(),
+                menu.getPrice(),
+                menu.getShop().getId(),
+                menu.getShop().getName()
+        );
+    }
+}


### PR DESCRIPTION
## 📒 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #46 

## 📒 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- (페이징 공통 응답 구현 뒤 리팩토링 예정)
- `도메인 별 공통 요구 사항`
```
서치에는 검색 조건 및 정렬 기능이 추가되어야 합니다.
정렬 기능은 기본적으로 생성일 순을 기준으로 합니다.
서치 기능에는 10건, 30건, 50건 기준으로 페이지에 노출 될 수 있습니다. 
해당 숫자와 다른 건수는 제한하여 기본 10건으로 고정합니다.
```

```java
   /**
     * 메뉴 이름 기반 조회 (검색)
     *
     * @param keyword  검색어
     * @param page     페이지 번호 (0부터 시작)
     * @param size     한 페이지에 가져올 메뉴 개수 (유효 size: 10, 30, 50; 이외 값 입력시 ** 10으로 고정 **)
     * @param sortBy   정렬할 필드명 (ex) "createdAt", "price")
     * @param isAsc    정렬 방향 (true: 오름차순, false: 내림차순(default))
     * @return         페이징된 메뉴 DTO Page<MenuSearchResponse>
     */
```
- **사용자가 다른 조건 없이 메뉴 이름만 검색했을 때의 디폴트 값**
```java
@RequestParam(value = "page", defaultValue = "0") int page,
@RequestParam(value = "size", defaultValue = "10") int size,
@RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy,
@RequestParam(value = "isAsc", defaultValue = "false") boolean isAsc
```
- 검색 시 N+1 문제가 발생해 `fetch join`, `@EntityGraph` 중 고민하다 우선 가장 간단하게 적용할 수 있는 `@EntityGraph`를 사용해 해결하였습니다.


🔗 참고 포스팅
[N+1을 해결하는 방법](https://9hyuk9.tistory.com/91)
[N+1 성능 비교](https://velog.io/@tak980418/Spring-JPA%EC%97%90%EC%84%9C-N-1-%EB%AC%B8%EC%A0%9C%EB%A5%BC-%ED%95%B4%EA%B2%B0%ED%95%98%EB%8A%94-%EB%B0%A9%EB%B2%95)


## 📒 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
더미데이터가 아직 충분하지 않아 동작 확인만 했습니다.

```
localhost:8080/v1/menus/search?keyword=&page=0&size=10&sortBy=createdAt&isAsc=true
```


```
localhost:8080/v1/menus/search?keyword=찌개
```
<img width="745" height="902" alt="스크린샷 2025-10-09 201540" src="https://github.com/user-attachments/assets/f9057ecb-3432-4a06-a407-c23e61e390a0" />

----

```
localhost:8080/v1/menus/search?keyword=파스타
```
<img width="772" height="902" alt="스크린샷 2025-10-09 192001" src="https://github.com/user-attachments/assets/7c8dd1a6-3058-434c-bbbc-ebe1b329de6e" />

----

```
localhost:8080/v1/menus/search?keyword=파스타&sortBy=price
```
<img width="826" height="909" alt="스크린샷 2025-10-09 192026" src="https://github.com/user-attachments/assets/8ed09e1f-f837-4c7c-ae43-68565862db7d" />

----

## 📒 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
- 요구 사항에 맞게 적절하게 구현 됐는 지
- 다른 예외 처리가 필요할 지
