### PR TITLE
feat: 회원정보 수정 API 구현

### DIFF
--- a/src/main/java/com/sparta/bapzip/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/bapzip/global/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     // USER 관련 에러
     DUPLICATE_USER_EXCEPTION(HttpStatus.CONFLICT, "중복 된 유저입니다."),
     UNAUTHORIZED_USER_EXCEPTION(HttpStatus.UNAUTHORIZED, "권한이 없는 유저입니다."),
+    PASSWORD_NOT_MATCH_EXCEPTION(HttpStatus.UNAUTHORIZED, "패스워드가 일치하지 않습니다."),
     USER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
 
     // MENU todo: 상태코드 별 분리 필요

--- a/src/main/java/com/sparta/bapzip/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/sparta/bapzip/global/infrastructure/config/security/SecurityConfig.java
@@ -5,9 +5,9 @@ import com.sparta.bapzip.user.jwt.JwtAuthenticationFilter;
 import com.sparta.bapzip.user.jwt.JwtAuthorizationFilter;
 import com.sparta.bapzip.user.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -67,7 +67,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests((authorizeHttpRequests) ->
                 authorizeHttpRequests
                         .requestMatchers("/v1/users/signup", "/v1/users/login").permitAll()
-                        .requestMatchers("/v1/users").hasAnyRole("MASTER", "MANAGER")
+                        .requestMatchers(HttpMethod.GET, "/v1/users").hasAnyRole("MASTER", "MANAGER")
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );
 

--- a/src/main/java/com/sparta/bapzip/user/application/UserServiceV1.java
+++ b/src/main/java/com/sparta/bapzip/user/application/UserServiceV1.java
@@ -1,8 +1,11 @@
 package com.sparta.bapzip.user.application;
 
 import com.sparta.bapzip.global.exception.ErrorCode;
+import com.sparta.bapzip.user.application.dto.request.UserUpdateRequestDto;
 import com.sparta.bapzip.user.application.dto.response.UserResponseDto;
+import com.sparta.bapzip.user.application.dto.response.UserUpdateResponseDto;
 import com.sparta.bapzip.user.application.excpetion.DuplicateUserException;
+import com.sparta.bapzip.user.application.excpetion.PasswordNotMatchException;
 import com.sparta.bapzip.user.application.excpetion.UnauthorizedUserException;
 import com.sparta.bapzip.user.application.excpetion.UserNotFoundException;
 import com.sparta.bapzip.user.domain.entity.UserEntity;
@@ -77,5 +80,19 @@ public class UserServiceV1 {
         return userRepository.findById(userId).orElseThrow(
                 () -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND_EXCEPTION)
         );
+    }
+
+    public UserUpdateResponseDto updateUser(UserUpdateRequestDto userUpdateRequestDto, UserEntity user) {
+        // 비밀번호가 일치 하는지 확인
+        if (!passwordEncoder.matches(userUpdateRequestDto.getPassword(), user.getPassword())) {
+            throw new PasswordNotMatchException(ErrorCode.PASSWORD_NOT_MATCH_EXCEPTION);
+        }
+
+        // 비밀번호가 일치하면 유저 이름과 변경할 패스워드 업데이트
+        user.update(userUpdateRequestDto, passwordEncoder);
+        user.markUpdated(user.getId());
+        UserEntity saveUser = userRepository.save(user);
+
+        return UserUpdateResponseDto.of(saveUser);
     }
 }

--- a/src/main/java/com/sparta/bapzip/user/application/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/sparta/bapzip/user/application/dto/request/SignupRequestDto.java
@@ -3,6 +3,8 @@ package com.sparta.bapzip.user.application.dto.request;
 import com.sparta.bapzip.user.domain.enums.UserRoleEnum;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -18,8 +20,9 @@ public class SignupRequestDto {
     private String name;
 
     @NotBlank
+    @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*]{8,16}$")
     private String password;
 
-    @NotBlank
+    @NotNull
     private UserRoleEnum role;
 }

--- a/src/main/java/com/sparta/bapzip/user/application/dto/request/UserUpdateRequestDto.java
+++ b/src/main/java/com/sparta/bapzip/user/application/dto/request/UserUpdateRequestDto.java
@@ -1,0 +1,24 @@
+package com.sparta.bapzip.user.application.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserUpdateRequestDto {
+
+    @Email
+    private String email;
+
+    private String name;
+
+    @NotBlank
+    @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*]{8,16}$")
+    private String password;
+
+    @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*]{8,16}$")
+    private String newPassword;
+}

--- a/src/main/java/com/sparta/bapzip/user/application/dto/response/UserUpdateResponseDto.java
+++ b/src/main/java/com/sparta/bapzip/user/application/dto/response/UserUpdateResponseDto.java
@@ -1,0 +1,32 @@
+package com.sparta.bapzip.user.application.dto.response;
+
+import com.sparta.bapzip.user.domain.entity.UserEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserUpdateResponseDto {
+
+    private Long id;
+
+    private String email;
+
+    private String name;
+
+    private LocalDateTime updatedAt;
+
+    private boolean isDeleted;
+
+    public static UserUpdateResponseDto of(UserEntity user) {
+        return UserUpdateResponseDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .updatedAt(user.getUpdatedAt())
+                .isDeleted(user.getIsDeleted())
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/bapzip/user/application/excpetion/PasswordNotMatchException.java
+++ b/src/main/java/com/sparta/bapzip/user/application/excpetion/PasswordNotMatchException.java
@@ -1,0 +1,11 @@
+package com.sparta.bapzip.user.application.excpetion;
+
+import com.sparta.bapzip.global.exception.ErrorCode;
+import com.sparta.bapzip.global.exception.GlobalException;
+
+public class PasswordNotMatchException extends GlobalException {
+
+    public PasswordNotMatchException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/sparta/bapzip/user/domain/entity/UserEntity.java
+++ b/src/main/java/com/sparta/bapzip/user/domain/entity/UserEntity.java
@@ -1,10 +1,12 @@
 package com.sparta.bapzip.user.domain.entity;
 
 import com.sparta.bapzip.global.common.BaseEntity;
+import com.sparta.bapzip.user.application.dto.request.UserUpdateRequestDto;
 import com.sparta.bapzip.user.domain.enums.UserRoleEnum;
 import com.sparta.bapzip.user.application.dto.request.SignupRequestDto;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
 @Table(name = "p_users")
@@ -38,5 +40,10 @@ public class UserEntity extends BaseEntity {
                 .password(encodingPassword)
                 .role(requestDto.getRole())
                 .build();
+    }
+
+    public void update(UserUpdateRequestDto requestDto, PasswordEncoder passwordEncoder) {
+        this.name = requestDto.getName() == null ? this.name : requestDto.getName();
+        this.password = requestDto.getNewPassword() == null ? this.password : passwordEncoder.encode(requestDto.getNewPassword());
     }
 }

--- a/src/main/java/com/sparta/bapzip/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/sparta/bapzip/user/presentation/controller/UserControllerV1.java
@@ -2,8 +2,10 @@ package com.sparta.bapzip.user.presentation.controller;
 
 import com.sparta.bapzip.user.application.UserServiceV1;
 import com.sparta.bapzip.user.application.dto.request.SignupRequestDto;
+import com.sparta.bapzip.user.application.dto.request.UserUpdateRequestDto;
 import com.sparta.bapzip.user.application.dto.response.SignupResponseDto;
 import com.sparta.bapzip.user.application.dto.response.UserResponseDto;
+import com.sparta.bapzip.user.application.dto.response.UserUpdateResponseDto;
 import com.sparta.bapzip.user.domain.entity.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,10 +26,10 @@ public class UserControllerV1 {
     }
 
     @GetMapping
-    public Page<UserResponseDto> getUserList(@RequestParam("page") int page,
-                                             @RequestParam("size") int size,
-                                             @RequestParam("sortBy") String sortBy,
-                                             @RequestParam("isAsc") boolean isAsc) {
+    public Page<UserResponseDto> getUserList(@RequestParam(value = "page", defaultValue = "1") int page,
+                                             @RequestParam(value = "size", defaultValue = "10") int size,
+                                             @RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy,
+                                             @RequestParam(value = "isAsc", defaultValue = "false") boolean isAsc) {
 
         return userServiceV1.getUserList(page - 1, size, sortBy, isAsc);
     }
@@ -35,5 +37,10 @@ public class UserControllerV1 {
     @GetMapping("/{userId}")
     public UserResponseDto getUser(@PathVariable Long userId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return userServiceV1.getUser(userId, userDetails.getUser());
+    }
+
+    @PatchMapping
+    public UserUpdateResponseDto updateUser(@RequestBody @Valid UserUpdateRequestDto userUpdateRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return userServiceV1.updateUser(userUpdateRequestDto, userDetails.getUser());
     }
 }

--- a/src/main/java/com/sparta/bapzip/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/sparta/bapzip/user/presentation/controller/UserControllerV1.java
@@ -1,11 +1,11 @@
 package com.sparta.bapzip.user.presentation.controller;
 
 import com.sparta.bapzip.user.application.UserServiceV1;
-import com.sparta.bapzip.user.application.dto.response.UserResponseDto;
-import com.sparta.bapzip.user.domain.entity.UserDetailsImpl;
-import com.sparta.bapzip.user.domain.entity.UserEntity;
 import com.sparta.bapzip.user.application.dto.request.SignupRequestDto;
 import com.sparta.bapzip.user.application.dto.response.SignupResponseDto;
+import com.sparta.bapzip.user.application.dto.response.UserResponseDto;
+import com.sparta.bapzip.user.domain.entity.UserDetailsImpl;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,7 +19,7 @@ public class UserControllerV1 {
     private final UserServiceV1 userServiceV1;
 
     @PostMapping("/signup")
-    public SignupResponseDto signup(@RequestBody SignupRequestDto requestDto) {
+    public SignupResponseDto signup(@RequestBody @Valid SignupRequestDto requestDto) {
         return userServiceV1.signup(requestDto);
     }
 


### PR DESCRIPTION
## 📒 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #59 

## 📒 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
회원정보 수정 API 구현, request 패스워드와 토큰 유저의 패스워드가 일치 시 유저 이름과, 비밀번호를 변경 가능하도록 구현

## 📒 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="944" height="840" alt="스크린샷 2025-10-10 오후 1 56 17" src="https://github.com/user-attachments/assets/9f0b731e-0fd8-4ea3-ace9-ad5767b77302" />

## 📒 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->

