### PR TITLE
feat: 로그인 사용자 기반 JPA Auditing 코드 추가

### DIFF
--- a/src/main/java/com/sparta/bapzip/BapzipApplication.java
+++ b/src/main/java/com/sparta/bapzip/BapzipApplication.java
@@ -1,18 +1,28 @@
 package com.sparta.bapzip;
 
+import com.sparta.bapzip.user.domain.entity.UserDetailsImpl;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.context.SecurityContextHolder;
 
-//@SpringBootApplication
+import java.util.Optional;
+
 @EnableJpaAuditing
-
-@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+@SpringBootApplication
 public class BapzipApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(BapzipApplication.class, args);
+    }
+
+    @Bean
+    public AuditorAware<Long> auditorProvider() {
+        // 인증 정보를 가져와 사용자의 ID 반환
+        return () -> Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+                .map(authentication -> ((UserDetailsImpl) authentication.getPrincipal()).getUser().getId());
     }
 
 }


### PR DESCRIPTION
## 📒 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #84 

## 📒 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- createBy, updateBy 자동 관리를 위한 로그인 사용자 기반 Auditing 코드 추가 => userId 추출
- 따로 config 클래스 분리 없이 바로 main에 추가했습니다.
- 적용이 정상적으로 되면 BaseEntity에 markCreated, update 메서드는 코드 정리 후 제거하면 될 거 같습니다.

## 📒 Test Result

- `AuthenticationPrincipal` 적용 컨트롤러 -> 메뉴 생성 시(created,updatedBy 값 확인)
<img width="623" height="757" alt="스크린샷 2025-10-13 161314" src="https://github.com/user-attachments/assets/c8f8e89e-fbe8-4e44-b272-4b015fa39696" />
<img width="953" height="174" alt="스크린샷 2025-10-13 161350" src="https://github.com/user-attachments/assets/7be2d25d-9a81-41a8-97e8-fad32fd0eec4" />



## 📒 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
- 컨트롤러에 `AuthenticationPrincipal` 적용한 분들 테스트 한 번 부탁 드려요!

