### PR TITLE
feat: 리뷰 삭제 기능 구현

### DIFF
--- a/src/main/java/com/sparta/bapzip/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/bapzip/global/exception/ErrorCode.java
@@ -74,7 +74,9 @@ public enum ErrorCode {
     SHOP_HAS_ACTIVE_ORDERS(HttpStatus.BAD_REQUEST, "진행 중인 주문이 있는 가게는 삭제할 수 없습니다."),
 
     // ====================== Review ======================
-    DUPLICATE_REVIEW(HttpStatus.CONFLICT, "이미 해당 주문에 대한 리뷰가 존재합니다.");
+    DUPLICATE_REVIEW(HttpStatus.CONFLICT, "이미 해당 주문에 대한 리뷰가 존재합니다."),
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰가 존재하지 않습니다."),
+    UNAUTHORIZED_REVIEW_ACCESS(HttpStatus.FORBIDDEN, "리뷰 작성자만 접근할 수 있습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/sparta/bapzip/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/bapzip/global/exception/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
     ORDER_NOT_DELIVERING(HttpStatus.BAD_REQUEST, "배달 중인 주문만 완료할 수 있습니다."),
     ORDER_NOT_CANCELLABLE(HttpStatus.BAD_REQUEST, "이미 처리 중인 주문은 취소할 수 없습니다."),
     FORBIDDEN_ORDER_ACCESS(HttpStatus.FORBIDDEN, "본인의 주문만 조회할 수 있습니다."),
+    ORDER_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "완료된 주문에 대해서만 리뷰룰 작성할 수 있습니다."),
 
     // ====================== Shop ======================
   
@@ -70,9 +71,10 @@ public enum ErrorCode {
     SHOP_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 가게를 삭제할 권한이 없습니다."),
     SHOP_ALREADY_DELETED(HttpStatus.CONFLICT, "이미 삭제된 가게입니다."),
     SHOP_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "가게 삭제 처리 중 오류가 발생했습니다."),
-    SHOP_HAS_ACTIVE_ORDERS(HttpStatus.BAD_REQUEST, "진행 중인 주문이 있는 가게는 삭제할 수 없습니다.");
+    SHOP_HAS_ACTIVE_ORDERS(HttpStatus.BAD_REQUEST, "진행 중인 주문이 있는 가게는 삭제할 수 없습니다."),
 
-    
+    // ====================== Review ======================
+    DUPLICATE_REVIEW(HttpStatus.CONFLICT, "이미 해당 주문에 대한 리뷰가 존재합니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/sparta/bapzip/order/application/OrderServiceV1.java
+++ b/src/main/java/com/sparta/bapzip/order/application/OrderServiceV1.java
@@ -127,6 +127,22 @@ public class OrderServiceV1 {
         order.delete(user.getId());
     }
 
+    /**
+     * 리뷰 작성 권한 검증을 포함한 주문 조회
+     *
+     * @param orderId 리뷰를 작성할 주문 ID
+     * @param user 현재 로그인한 사용자
+     */
+    @Transactional(readOnly = true)
+    public OrderEntity getOrderByIdForReview(UUID orderId, UserEntity user) {
+        OrderEntity order = getById(orderId);
+
+        order.validateCustomer(user.getId());
+        order.validateCompleted();
+
+        return order;
+    }
+
     // ========== 주문 상태 변경 (OWNER) ==========
 
     /**

--- a/src/main/java/com/sparta/bapzip/order/domain/entity/OrderEntity.java
+++ b/src/main/java/com/sparta/bapzip/order/domain/entity/OrderEntity.java
@@ -167,6 +167,17 @@ public class OrderEntity extends BaseEntity {
         }
     }
 
+    /**
+     * 배달 완료된 주문인지 검증
+     *
+     * @throws OrderNotCompletedException 주문이 배달 완료 상태가 아닌 경우
+     */
+    public void validateCompleted() {
+        if (this.status != OrderStatus.DELIVERED) {
+            throw new OrderNotCompletedException(ORDER_NOT_COMPLETED);
+        }
+    }
+
     // ========== 상태 변경 비즈니스 로직 ==========
 
     /**

--- a/src/main/java/com/sparta/bapzip/order/domain/exception/OrderNotCompletedException.java
+++ b/src/main/java/com/sparta/bapzip/order/domain/exception/OrderNotCompletedException.java
@@ -1,0 +1,10 @@
+package com.sparta.bapzip.order.domain.exception;
+
+import com.sparta.bapzip.global.exception.ErrorCode;
+import com.sparta.bapzip.global.exception.GlobalException;
+
+public class OrderNotCompletedException extends GlobalException {
+    public OrderNotCompletedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/sparta/bapzip/review/application/ReviewServiceV1.java
+++ b/src/main/java/com/sparta/bapzip/review/application/ReviewServiceV1.java
@@ -5,7 +5,10 @@ import com.sparta.bapzip.order.application.OrderServiceV1;
 import com.sparta.bapzip.order.domain.entity.OrderEntity;
 import com.sparta.bapzip.review.application.dto.ReviewDto;
 import com.sparta.bapzip.review.application.dto.request.CreateReviewRequest;
+import com.sparta.bapzip.review.application.dto.request.UpdateReviewRequest;
 import com.sparta.bapzip.review.application.exception.DuplicateReviewException;
+import com.sparta.bapzip.review.application.exception.ReviewNotFoundException;
+import com.sparta.bapzip.review.application.exception.UnauthorizedReviewAccessException;
 import com.sparta.bapzip.review.domain.entity.ReviewEntity;
 import com.sparta.bapzip.review.domain.repository.ReviewRepository;
 import com.sparta.bapzip.review.presentation.dto.response.ReviewCreateResponse;
@@ -111,5 +114,38 @@ public class ReviewServiceV1 {
         return reviews.stream().map(ReviewDto::from).collect(Collectors.toList());
     }
 
+
+    /**
+     * 리뷰를 부분 수정(PATCH)합니다.
+     *
+     * <p>
+     * 지정된 리뷰 ID와 사용자 정보를 기반으로 리뷰를 수정합니다.
+     * {@link UpdateReviewRequest}의 필드(score, content)만 업데이트하며,
+     * 리뷰 작성자가 아닌 경우 수정할 수 없습니다.
+     * 수정 후 {@link ReviewDto} 형태로 반환합니다.
+     * </p>
+     *
+     * @param user       리뷰 작성자 정보
+     * @param reviewId   수정할 리뷰 ID
+     * @param request    리뷰 수정 요청 DTO
+     * @return 수정된 리뷰 정보를 담은 {@link ReviewDto}
+     * @throws IllegalStateException    리뷰 작성자가 아닌 사용자가 수정 요청을 한 경우
+     * @throws IllegalArgumentException 존재하지 않는 리뷰 ID가 전달된 경우
+     */
+    @Transactional
+    public ReviewDto updateReview(UserEntity user, String reviewId, UpdateReviewRequest request) {
+        ReviewEntity review = reviewRepository.findById(UUID.fromString(reviewId))
+                .orElseThrow(() -> new ReviewNotFoundException(ErrorCode.REVIEW_NOT_FOUND));
+
+        // 작성자 체크
+        if (!review.getUser().getId().equals(user.getId())) {
+            throw new UnauthorizedReviewAccessException(ErrorCode.UNAUTHORIZED_REVIEW_ACCESS);
+        }
+
+        // 리뷰 수정
+        review.updateReview(request.getScore(), request.getContent());
+
+        return ReviewDto.from(review);
+    }
 
 }

--- a/src/main/java/com/sparta/bapzip/review/application/ReviewServiceV1.java
+++ b/src/main/java/com/sparta/bapzip/review/application/ReviewServiceV1.java
@@ -3,6 +3,7 @@ package com.sparta.bapzip.review.application;
 import com.sparta.bapzip.global.exception.ErrorCode;
 import com.sparta.bapzip.order.application.OrderServiceV1;
 import com.sparta.bapzip.order.domain.entity.OrderEntity;
+import com.sparta.bapzip.review.application.dto.ReviewDto;
 import com.sparta.bapzip.review.application.dto.request.CreateReviewRequest;
 import com.sparta.bapzip.review.application.exception.DuplicateReviewException;
 import com.sparta.bapzip.review.domain.entity.ReviewEntity;
@@ -16,8 +17,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 /**
- * 리뷰 관련 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ * 리뷰 관련 비즈니스 로직을 처리하는 서비스 클래스
  *
  * <p>리뷰 작성, 중복 리뷰 체크, 가게 및 주문 조회 등의 기능을 수행합니다.</p>
  */
@@ -27,7 +32,6 @@ public class ReviewServiceV1 {
 
     private final ReviewRepository reviewRepository;
     private final ShopServiceV1 shopServiceV1;
-    private final UserServiceV1 userServiceV1;
     private final OrderServiceV1 orderServiceV1;
 
     /**
@@ -72,4 +76,40 @@ public class ReviewServiceV1 {
         // 5. DTO 변환 후 반환
         return ReviewCreateResponse.from(savedReview);
     }
+
+    /**
+     * 특정 가게에 작성된 모든 리뷰를 조회합니다.
+     *
+     * @param shopId 조회할 가게의 ID
+     * @return 조회된 리뷰 리스트를 {@link ReviewDto} 형태로 반환
+     */
+    public List<ReviewDto> getReviewsByShop(String shopId) {
+        List<ReviewEntity> reviews = reviewRepository.findAllByShopId(UUID.fromString(shopId));
+        return reviews.stream().map(ReviewDto::from).collect(Collectors.toList());
+    }
+
+    /**
+     * 특정 사용자가 작성한 모든 리뷰를 조회합니다.
+     *
+     * @param user 조회할 사용자
+     * @return 조회된 리뷰 리스트를 {@link ReviewDto} 형태로 반환
+     */
+    public List<ReviewDto> getMyReviews(UserEntity user) {
+        List<ReviewEntity> reviews = reviewRepository.findAllByUserId(user.getId());
+        return reviews.stream().map(ReviewDto::from).collect(Collectors.toList());
+    }
+
+    /**
+     * 특정 사용자가 작성한 특정 가게 리뷰를 조회합니다.
+     *
+     * @param user   조회할 사용자
+     * @param shopId 조회할 가게의 ID
+     * @return 조회된 리뷰 리스트를 {@link ReviewDto} 형태로 반환
+     */
+    public List<ReviewDto> getMyReviewsByShop(UserEntity user, String shopId) {
+        List<ReviewEntity> reviews = reviewRepository.findAllByUserIdAndShopId(user.getId(), UUID.fromString(shopId));
+        return reviews.stream().map(ReviewDto::from).collect(Collectors.toList());
+    }
+
+
 }

--- a/src/main/java/com/sparta/bapzip/review/application/ReviewServiceV1.java
+++ b/src/main/java/com/sparta/bapzip/review/application/ReviewServiceV1.java
@@ -1,7 +1,57 @@
 package com.sparta.bapzip.review.application;
 
+import com.sparta.bapzip.global.exception.ErrorCode;
+import com.sparta.bapzip.order.application.OrderServiceV1;
+import com.sparta.bapzip.order.domain.entity.OrderEntity;
+import com.sparta.bapzip.order.domain.repository.OrderRepository;
+import com.sparta.bapzip.review.application.dto.request.CreateReviewRequest;
+import com.sparta.bapzip.review.application.exception.DuplicateReviewException;
+import com.sparta.bapzip.review.domain.entity.ReviewEntity;
+import com.sparta.bapzip.review.domain.repository.ReviewRepository;
+import com.sparta.bapzip.review.presentation.dto.response.ReviewCreateResponse;
+import com.sparta.bapzip.shop.application.ShopServiceV1;
+import com.sparta.bapzip.shop.domain.entity.ShopEntity;
+import com.sparta.bapzip.user.application.UserServiceV1;
+import com.sparta.bapzip.user.domain.entity.UserEntity;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class ReviewServiceV1 {
+
+    private final ReviewRepository reviewRepository;
+    private final ShopServiceV1 shopServiceV1;
+    private final UserServiceV1 userServiceV1;
+    private final OrderServiceV1 orderServiceV1;
+
+    @Transactional
+    public ReviewCreateResponse createReview(UserEntity user, CreateReviewRequest request) {
+
+        // 1. 중복 리뷰 확인
+        if (reviewRepository.existsByOrderIdAndUserId(request.getOrderId(), user.getId())) {
+            throw new DuplicateReviewException(ErrorCode.DUPLICATE_REVIEW);
+        }
+
+        // 2. 가게 조회
+        ShopEntity shop = shopServiceV1.getShopById(request.getShopId());
+
+        // 3. 주문 조회 (작성 권한 체크 포함)
+        OrderEntity order = orderServiceV1.getOrderByIdForReview(request.getOrderId(), user);
+
+        // 4. 리뷰 생성
+        ReviewEntity review = ReviewEntity.builder()
+                .score(request.getScore())
+                .content(request.getContent())
+                .shop(shop)
+                .user(user)
+                .order(order)
+                .build();
+
+        ReviewEntity savedReview = reviewRepository.save(review);
+
+        // 5. DTO 변환 후 반환
+        return ReviewCreateResponse.from(savedReview);
+    }
 }

--- a/src/main/java/com/sparta/bapzip/review/application/ReviewServiceV1.java
+++ b/src/main/java/com/sparta/bapzip/review/application/ReviewServiceV1.java
@@ -3,7 +3,6 @@ package com.sparta.bapzip.review.application;
 import com.sparta.bapzip.global.exception.ErrorCode;
 import com.sparta.bapzip.order.application.OrderServiceV1;
 import com.sparta.bapzip.order.domain.entity.OrderEntity;
-import com.sparta.bapzip.order.domain.repository.OrderRepository;
 import com.sparta.bapzip.review.application.dto.request.CreateReviewRequest;
 import com.sparta.bapzip.review.application.exception.DuplicateReviewException;
 import com.sparta.bapzip.review.domain.entity.ReviewEntity;
@@ -17,6 +16,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 리뷰 관련 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ *
+ * <p>리뷰 작성, 중복 리뷰 체크, 가게 및 주문 조회 등의 기능을 수행합니다.</p>
+ */
 @Service
 @RequiredArgsConstructor
 public class ReviewServiceV1 {
@@ -26,6 +30,20 @@ public class ReviewServiceV1 {
     private final UserServiceV1 userServiceV1;
     private final OrderServiceV1 orderServiceV1;
 
+    /**
+     * 사용자가 작성한 리뷰를 생성합니다.
+     *
+     * <p>1. 주문과 사용자 기준으로 중복 리뷰 확인<br>
+     * 2. 가게 조회<br>
+     * 3. 주문 조회 및 작성 권한 확인<br>
+     * 4. 리뷰 생성 및 저장<br>
+     * 5. 저장된 리뷰를 DTO로 변환 후 반환</p>
+     *
+     * @param user    리뷰를 작성하는 사용자
+     * @param request 리뷰 작성 요청 DTO
+     * @return 생성된 리뷰 정보를 담은 {@link ReviewCreateResponse} 객체
+     * @throws DuplicateReviewException 동일 주문에 대해 이미 작성된 리뷰가 존재할 경우 발생
+     */
     @Transactional
     public ReviewCreateResponse createReview(UserEntity user, CreateReviewRequest request) {
 

--- a/src/main/java/com/sparta/bapzip/review/application/dto/ReviewDto.java
+++ b/src/main/java/com/sparta/bapzip/review/application/dto/ReviewDto.java
@@ -1,4 +1,52 @@
 package com.sparta.bapzip.review.application.dto;
 
+import com.sparta.bapzip.review.domain.entity.ReviewEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 리뷰 조회용 DTO 클래스.
+ * <p>
+ * 프론트엔드에서 가게 리뷰 목록을 보여주기 위해 사용되며,
+ * 리뷰 엔티티를 안전하게 전달하기 위한 데이터 전송 객체입니다.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
 public class ReviewDto {
+
+    /** 리뷰 ID */
+    private UUID id;
+
+    /** 리뷰 평점 */
+    private int score;
+
+    /** 리뷰 내용 */
+    private String content;
+
+    /** 리뷰 작성자 이름 */
+    private String userName;
+
+    /** 리뷰 작성일시 */
+    private LocalDateTime createdAt;
+
+    /**
+     * ReviewEntity를 ReviewDto로 변환합니다.
+     *
+     * @param review 변환할 리뷰 엔티티
+     * @return ReviewDto 객체
+     */
+    public static ReviewDto from(ReviewEntity review) {
+        return ReviewDto.builder()
+                .id(review.getId())
+                .score(review.getScore())
+                .content(review.getContent())
+                .userName(review.getUser().getName())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/sparta/bapzip/review/application/dto/ReviewDto.java
+++ b/src/main/java/com/sparta/bapzip/review/application/dto/ReviewDto.java
@@ -1,0 +1,4 @@
+package com.sparta.bapzip.review.application.dto;
+
+public class ReviewDto {
+}

--- a/src/main/java/com/sparta/bapzip/review/application/dto/request/CreateReviewRequest.java
+++ b/src/main/java/com/sparta/bapzip/review/application/dto/request/CreateReviewRequest.java
@@ -1,0 +1,23 @@
+package com.sparta.bapzip.review.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class CreateReviewRequest {
+
+    @NotNull
+    private Integer score;
+
+    @NotBlank
+    private String content;
+
+    @NotNull
+    private UUID shopId;
+
+    @NotNull
+    private UUID orderId;
+}

--- a/src/main/java/com/sparta/bapzip/review/application/dto/request/CreateReviewRequest.java
+++ b/src/main/java/com/sparta/bapzip/review/application/dto/request/CreateReviewRequest.java
@@ -6,18 +6,42 @@ import lombok.Getter;
 
 import java.util.UUID;
 
+/**
+ * 리뷰 작성 요청을 위한 DTO(Data Transfer Object) 클래스입니다.
+ * 클라이언트로부터 리뷰 점수, 내용, 주문 및 매장 정보를 전달받습니다.
+ */
 @Getter
 public class CreateReviewRequest {
 
+    /**
+     * 리뷰 점수
+     * <p>
+     * 필수 입력 값이며, 정수형으로 작성합니다.
+     */
     @NotNull
     private Integer score;
 
+    /**
+     * 리뷰 내용
+     * <p>
+     * 필수 입력 값이며, 공백이 아닌 문자열이어야 합니다.
+     */
     @NotBlank
     private String content;
 
+    /**
+     * 리뷰 대상 매장의 ID
+     * <p>
+     * 필수 입력 값이며, UUID 형식이어야 합니다.
+     */
     @NotNull
     private UUID shopId;
 
+    /**
+     * 리뷰 대상 주문의 ID
+     * <p>
+     * 필수 입력 값이며, UUID 형식이어야 합니다.
+     */
     @NotNull
     private UUID orderId;
 }

--- a/src/main/java/com/sparta/bapzip/review/application/dto/request/UpdateReviewRequest.java
+++ b/src/main/java/com/sparta/bapzip/review/application/dto/request/UpdateReviewRequest.java
@@ -1,0 +1,15 @@
+package com.sparta.bapzip.review.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class UpdateReviewRequest {
+
+    @NotNull
+    private Integer score; // 새로운 평점
+
+    @NotBlank
+    private String content; // 새로운 리뷰 내용
+}

--- a/src/main/java/com/sparta/bapzip/review/application/exception/DuplicateReviewException.java
+++ b/src/main/java/com/sparta/bapzip/review/application/exception/DuplicateReviewException.java
@@ -3,7 +3,15 @@ package com.sparta.bapzip.review.application.exception;
 import com.sparta.bapzip.global.exception.ErrorCode;
 import com.sparta.bapzip.global.exception.GlobalException;
 
+/**
+ * 동일 주문에 대해 사용자가 이미 작성한 리뷰가 존재할 경우 발생하는 예외 클래스입니다.
+ */
 public class DuplicateReviewException extends GlobalException {
+    /**
+     * 중복 리뷰 예외 생성자
+     *
+     * @param errorCode 발생할 에러 코드
+     */
     public DuplicateReviewException(ErrorCode errorCode) {
         super(errorCode);
     }

--- a/src/main/java/com/sparta/bapzip/review/application/exception/DuplicateReviewException.java
+++ b/src/main/java/com/sparta/bapzip/review/application/exception/DuplicateReviewException.java
@@ -1,0 +1,10 @@
+package com.sparta.bapzip.review.application.exception;
+
+import com.sparta.bapzip.global.exception.ErrorCode;
+import com.sparta.bapzip.global.exception.GlobalException;
+
+public class DuplicateReviewException extends GlobalException {
+    public DuplicateReviewException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/sparta/bapzip/review/application/exception/ReviewNotFoundException.java
+++ b/src/main/java/com/sparta/bapzip/review/application/exception/ReviewNotFoundException.java
@@ -4,21 +4,21 @@ import com.sparta.bapzip.global.exception.ErrorCode;
 import com.sparta.bapzip.global.exception.GlobalException;
 
 /**
- * 동일 주문에 대해 사용자가 이미 작성한 리뷰가 존재할 경우 발생하는 커스텀 예외 클래스입니다.
+ * 리뷰를 찾을 수 없을 때 발생하는 커스텀 예외 클래스입니다.
  *
  * <p>
- * 리뷰 생성 시, 같은 주문에 대해 중복 리뷰 작성이 시도될 때 사용됩니다.
+ * 존재하지 않는 리뷰 ID로 접근 시 사용됩니다.
  * {@link ErrorCode}를 기반으로 예외 메시지와 상태 코드를 제공합니다.
  * </p>
  */
-public class DuplicateReviewException extends GlobalException {
+public class ReviewNotFoundException extends GlobalException {
 
     /**
      * 생성자
      *
      * @param errorCode 발생할 에러 코드
      */
-    public DuplicateReviewException(ErrorCode errorCode) {
+    public ReviewNotFoundException(ErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/src/main/java/com/sparta/bapzip/review/application/exception/UnauthorizedReviewAccessException.java
+++ b/src/main/java/com/sparta/bapzip/review/application/exception/UnauthorizedReviewAccessException.java
@@ -4,21 +4,21 @@ import com.sparta.bapzip.global.exception.ErrorCode;
 import com.sparta.bapzip.global.exception.GlobalException;
 
 /**
- * 동일 주문에 대해 사용자가 이미 작성한 리뷰가 존재할 경우 발생하는 커스텀 예외 클래스입니다.
+ * 리뷰 작성자가 아닌 사용자가 리뷰에 접근하려고 할 때 발생하는 커스텀 예외 클래스입니다.
  *
  * <p>
- * 리뷰 생성 시, 같은 주문에 대해 중복 리뷰 작성이 시도될 때 사용됩니다.
+ * 리뷰 수정, 삭제 등 작성자 전용 작업 시 권한이 없는 사용자가 요청할 경우 사용됩니다.
  * {@link ErrorCode}를 기반으로 예외 메시지와 상태 코드를 제공합니다.
  * </p>
  */
-public class DuplicateReviewException extends GlobalException {
+public class UnauthorizedReviewAccessException extends GlobalException {
 
     /**
      * 생성자
      *
      * @param errorCode 발생할 에러 코드
      */
-    public DuplicateReviewException(ErrorCode errorCode) {
+    public UnauthorizedReviewAccessException(ErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/src/main/java/com/sparta/bapzip/review/domain/entity/ReviewEntity.java
+++ b/src/main/java/com/sparta/bapzip/review/domain/entity/ReviewEntity.java
@@ -66,4 +66,16 @@ public class ReviewEntity extends BaseEntity {
     @JoinColumn(name = "order_id", nullable = false)
     @OneToOne
     private OrderEntity order;
+
+
+
+    /**
+     * 리뷰 내용을 수정합니다.
+     * @param newScore 새로운 평점
+     * @param newContent 새로운 내용
+     */
+    public void updateReview(int newScore, String newContent) {
+        this.score = newScore;
+        this.content = newContent;
+    }
 }

--- a/src/main/java/com/sparta/bapzip/review/domain/entity/ReviewEntity.java
+++ b/src/main/java/com/sparta/bapzip/review/domain/entity/ReviewEntity.java
@@ -12,6 +12,13 @@ import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
+/**
+ * 리뷰(Review) 엔티티를 나타내는 클래스입니다.
+ *
+ * <p>리뷰는 특정 주문(Order), 사용자(User), 그리고 가게(Shop)에 연결되어 있으며,
+ * 점수(score)와 내용(content)을 포함합니다. {@link BaseEntity}를 상속받아
+ * 생성일, 수정일 등의 공통 필드를 포함합니다.</p>
+ */
 @Entity
 @Table(name = "p_reviews")
 @Getter
@@ -20,27 +27,43 @@ import java.util.UUID;
 @AllArgsConstructor
 public class ReviewEntity extends BaseEntity {
 
+    /**
+     * 리뷰의 고유 ID
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
+    /**
+     * 리뷰 점수
+     */
     @Column(nullable = false)
     private int score;
 
+    /**
+     * 리뷰 내용
+     */
     @Column(nullable = false)
     private String content;
 
-    @JoinColumn(name = "user_id", nullable = false )
+    /**
+     * 리뷰를 작성한 사용자
+     */
+    @JoinColumn(name = "user_id", nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private UserEntity user;
 
-    @JoinColumn(name = "shop_id", nullable = false )
+    /**
+     * 리뷰 대상 가게
+     */
+    @JoinColumn(name = "shop_id", nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private ShopEntity shop;
 
-    @JoinColumn(name = "order_id", nullable = false )
+    /**
+     * 리뷰가 연결된 주문
+     */
+    @JoinColumn(name = "order_id", nullable = false)
     @OneToOne
     private OrderEntity order;
-
-
 }

--- a/src/main/java/com/sparta/bapzip/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/bapzip/review/domain/repository/ReviewRepository.java
@@ -3,6 +3,7 @@ package com.sparta.bapzip.review.domain.repository;
 import com.sparta.bapzip.review.domain.entity.ReviewEntity;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -52,4 +53,6 @@ public interface ReviewRepository {
      * @return 조회된 {@link ReviewEntity} 리스트
      */
     List<ReviewEntity> findAllByUserIdAndShopId(Long userId, UUID shopId);
+
+    Optional<ReviewEntity> findById(UUID reviewId);
 }

--- a/src/main/java/com/sparta/bapzip/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/bapzip/review/domain/repository/ReviewRepository.java
@@ -2,6 +2,7 @@ package com.sparta.bapzip.review.domain.repository;
 
 import com.sparta.bapzip.review.domain.entity.ReviewEntity;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -26,4 +27,29 @@ public interface ReviewRepository {
      * @return 리뷰가 존재하면 {@code true}, 존재하지 않으면 {@code false}
      */
     boolean existsByOrderIdAndUserId(UUID orderId, Long userId);
+
+    /**
+     * 특정 가게에 작성된 모든 리뷰를 조회합니다.
+     *
+     * @param shopId 조회할 가게 ID
+     * @return 조회된 {@link ReviewEntity} 리스트
+     */
+    List<ReviewEntity> findAllByShopId(UUID shopId);
+
+    /**
+     * 특정 사용자가 작성한 모든 리뷰를 조회합니다.
+     *
+     * @param userId 조회할 사용자 ID
+     * @return 조회된 {@link ReviewEntity} 리스트
+     */
+    List<ReviewEntity> findAllByUserId(Long userId);
+
+    /**
+     * 특정 사용자가 작성한 특정 가게 리뷰를 조회합니다.
+     *
+     * @param userId 조회할 사용자 ID
+     * @param shopId 조회할 가게 ID
+     * @return 조회된 {@link ReviewEntity} 리스트
+     */
+    List<ReviewEntity> findAllByUserIdAndShopId(Long userId, UUID shopId);
 }

--- a/src/main/java/com/sparta/bapzip/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/bapzip/review/domain/repository/ReviewRepository.java
@@ -1,4 +1,11 @@
 package com.sparta.bapzip.review.domain.repository;
 
+import com.sparta.bapzip.review.domain.entity.ReviewEntity;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
 public interface ReviewRepository {
+    ReviewEntity save(ReviewEntity review);
+    boolean existsByOrderIdAndUserId(UUID orderId, Long userId);
 }

--- a/src/main/java/com/sparta/bapzip/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/bapzip/review/domain/repository/ReviewRepository.java
@@ -1,11 +1,29 @@
 package com.sparta.bapzip.review.domain.repository;
 
 import com.sparta.bapzip.review.domain.entity.ReviewEntity;
-import jakarta.validation.constraints.NotNull;
 
 import java.util.UUID;
 
+/**
+ * 리뷰 엔티티에 대한 도메인 레벨의 저장소 인터페이스입니다.
+ * 데이터베이스 접근에 대한 추상화를 제공하며, 구현체는 구체적인 DB 접근 방식을 처리합니다.
+ */
 public interface ReviewRepository {
+
+    /**
+     * 새로운 리뷰를 저장합니다.
+     *
+     * @param review 저장할 {@link ReviewEntity} 객체
+     * @return 저장된 {@link ReviewEntity} 객체
+     */
     ReviewEntity save(ReviewEntity review);
+
+    /**
+     * 특정 주문과 사용자에 대해 리뷰가 이미 존재하는지 확인합니다.
+     *
+     * @param orderId 확인할 주문 ID
+     * @param userId  확인할 사용자 ID
+     * @return 리뷰가 존재하면 {@code true}, 존재하지 않으면 {@code false}
+     */
     boolean existsByOrderIdAndUserId(UUID orderId, Long userId);
 }

--- a/src/main/java/com/sparta/bapzip/review/infrastructure/repository/ReviewJpaRepository.java
+++ b/src/main/java/com/sparta/bapzip/review/infrastructure/repository/ReviewJpaRepository.java
@@ -3,6 +3,7 @@ package com.sparta.bapzip.review.infrastructure.repository;
 import com.sparta.bapzip.review.domain.entity.ReviewEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -19,4 +20,29 @@ public interface ReviewJpaRepository extends JpaRepository<ReviewEntity, UUID> {
      * @return 리뷰가 존재하면 {@code true}, 존재하지 않으면 {@code false}
      */
     boolean existsByOrderIdAndUserId(UUID orderId, Long userId);
+
+    /**
+     * 특정 가게에 작성된 모든 리뷰를 조회합니다.
+     *
+     * @param shopId 조회할 가게 ID
+     * @return 조회된 {@link ReviewEntity} 리스트
+     */
+    List<ReviewEntity> findAllByShopId(UUID shopId);
+
+    /**
+     * 특정 사용자가 작성한 모든 리뷰를 조회합니다.
+     *
+     * @param userId 조회할 사용자 ID
+     * @return 조회된 {@link ReviewEntity} 리스트
+     */
+    List<ReviewEntity> findAllByUserId(Long userId);
+
+    /**
+     * 특정 사용자가 작성한 특정 가게 리뷰를 조회합니다.
+     *
+     * @param userId 조회할 사용자 ID
+     * @param shopId 조회할 가게 ID
+     * @return 조회된 {@link ReviewEntity} 리스트
+     */
+    List<ReviewEntity> findAllByUserIdAndShopId(Long userId, UUID shopId);
 }

--- a/src/main/java/com/sparta/bapzip/review/infrastructure/repository/ReviewJpaRepository.java
+++ b/src/main/java/com/sparta/bapzip/review/infrastructure/repository/ReviewJpaRepository.java
@@ -5,6 +5,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
+/**
+ * 리뷰 엔티티에 대한 JPA Repository 인터페이스입니다.
+ * Spring Data JPA를 사용하여 데이터베이스 CRUD 및 커스텀 쿼리 기능을 제공합니다.
+ */
 public interface ReviewJpaRepository extends JpaRepository<ReviewEntity, UUID> {
+
+    /**
+     * 특정 주문과 사용자에 대해 리뷰가 이미 존재하는지 확인합니다.
+     *
+     * @param orderId 확인할 주문 ID
+     * @param userId  확인할 사용자 ID
+     * @return 리뷰가 존재하면 {@code true}, 존재하지 않으면 {@code false}
+     */
     boolean existsByOrderIdAndUserId(UUID orderId, Long userId);
 }

--- a/src/main/java/com/sparta/bapzip/review/infrastructure/repository/ReviewJpaRepository.java
+++ b/src/main/java/com/sparta/bapzip/review/infrastructure/repository/ReviewJpaRepository.java
@@ -1,0 +1,10 @@
+package com.sparta.bapzip.review.infrastructure.repository;
+
+import com.sparta.bapzip.review.domain.entity.ReviewEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ReviewJpaRepository extends JpaRepository<ReviewEntity, UUID> {
+    boolean existsByOrderIdAndUserId(UUID orderId, Long userId);
+}

--- a/src/main/java/com/sparta/bapzip/review/infrastructure/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/sparta/bapzip/review/infrastructure/repository/ReviewRepositoryImpl.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -73,5 +74,10 @@ public class ReviewRepositoryImpl implements ReviewRepository {
     @Override
     public List<ReviewEntity> findAllByUserIdAndShopId(Long userId, UUID shopId) {
         return reviewJpaRepository.findAllByUserIdAndShopId(userId, shopId);
+    }
+
+    @Override
+    public Optional<ReviewEntity> findById(UUID reviewId) {
+        return reviewJpaRepository.findById(reviewId);
     }
 }

--- a/src/main/java/com/sparta/bapzip/review/infrastructure/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/sparta/bapzip/review/infrastructure/repository/ReviewRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.sparta.bapzip.review.domain.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -38,5 +39,39 @@ public class ReviewRepositoryImpl implements ReviewRepository {
     @Override
     public boolean existsByOrderIdAndUserId(UUID orderId, Long userId) {
         return reviewJpaRepository.existsByOrderIdAndUserId(orderId, userId);
+    }
+
+    /**
+     * 특정 가게에 작성된 모든 리뷰를 조회합니다.
+     *
+     * @param shopId 조회할 가게 ID
+     * @return 조회된 {@link ReviewEntity} 리스트
+     */
+    @Override
+    public List<ReviewEntity> findAllByShopId(UUID shopId) {
+        return reviewJpaRepository.findAllByShopId(shopId);
+    }
+
+    /**
+     * 특정 사용자가 작성한 모든 리뷰를 조회합니다.
+     *
+     * @param userId 조회할 사용자 ID
+     * @return 조회된 {@link ReviewEntity} 리스트
+     */
+    @Override
+    public List<ReviewEntity> findAllByUserId(Long userId) {
+        return reviewJpaRepository.findAllByUserId(userId);
+    }
+
+    /**
+     * 특정 사용자가 작성한 특정 가게 리뷰를 조회합니다.
+     *
+     * @param userId 조회할 사용자 ID
+     * @param shopId 조회할 가게 ID
+     * @return 조회된 {@link ReviewEntity} 리스트
+     */
+    @Override
+    public List<ReviewEntity> findAllByUserIdAndShopId(Long userId, UUID shopId) {
+        return reviewJpaRepository.findAllByUserIdAndShopId(userId, shopId);
     }
 }

--- a/src/main/java/com/sparta/bapzip/review/infrastructure/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/sparta/bapzip/review/infrastructure/repository/ReviewRepositoryImpl.java
@@ -7,17 +7,34 @@ import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
 
+/**
+ * {@link ReviewRepository} 인터페이스를 구현한 클래스입니다.
+ * JPA를 사용하여 리뷰 엔티티의 저장 및 조회 기능을 제공합니다.
+ */
 @Repository
 @RequiredArgsConstructor
 public class ReviewRepositoryImpl implements ReviewRepository {
 
     private final ReviewJpaRepository reviewJpaRepository;
 
+    /**
+     * 리뷰 엔티티를 저장합니다.
+     *
+     * @param review 저장할 {@link ReviewEntity} 객체
+     * @return 저장된 {@link ReviewEntity} 객체
+     */
     @Override
     public ReviewEntity save(ReviewEntity review) {
         return reviewJpaRepository.save(review);
     }
 
+    /**
+     * 특정 주문과 사용자에 대해 리뷰가 이미 존재하는지 확인합니다.
+     *
+     * @param orderId 확인할 주문 ID
+     * @param userId  확인할 사용자 ID
+     * @return 리뷰가 존재하면 {@code true}, 존재하지 않으면 {@code false}
+     */
     @Override
     public boolean existsByOrderIdAndUserId(UUID orderId, Long userId) {
         return reviewJpaRepository.existsByOrderIdAndUserId(orderId, userId);

--- a/src/main/java/com/sparta/bapzip/review/infrastructure/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/sparta/bapzip/review/infrastructure/repository/ReviewRepositoryImpl.java
@@ -1,6 +1,25 @@
 package com.sparta.bapzip.review.infrastructure.repository;
 
+import com.sparta.bapzip.review.domain.entity.ReviewEntity;
 import com.sparta.bapzip.review.domain.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
 public class ReviewRepositoryImpl implements ReviewRepository {
+
+    private final ReviewJpaRepository reviewJpaRepository;
+
+    @Override
+    public ReviewEntity save(ReviewEntity review) {
+        return reviewJpaRepository.save(review);
+    }
+
+    @Override
+    public boolean existsByOrderIdAndUserId(UUID orderId, Long userId) {
+        return reviewJpaRepository.existsByOrderIdAndUserId(orderId, userId);
+    }
 }

--- a/src/main/java/com/sparta/bapzip/review/presentation/controller/ReviewControllerV1.java
+++ b/src/main/java/com/sparta/bapzip/review/presentation/controller/ReviewControllerV1.java
@@ -4,6 +4,7 @@ import com.sparta.bapzip.global.response.ApiResponse;
 import com.sparta.bapzip.review.application.ReviewServiceV1;
 import com.sparta.bapzip.review.application.dto.ReviewDto;
 import com.sparta.bapzip.review.application.dto.request.CreateReviewRequest;
+import com.sparta.bapzip.review.application.dto.request.UpdateReviewRequest;
 import com.sparta.bapzip.review.presentation.dto.response.ReviewCreateResponse;
 import com.sparta.bapzip.user.domain.entity.UserDetailsImpl;
 import jakarta.validation.Valid;
@@ -51,6 +52,7 @@ public class ReviewControllerV1 {
         return ApiResponse.created(response);
     }
 
+
     /**
      * 특정 가게에 작성된 모든 리뷰를 조회합니다.
      *
@@ -89,5 +91,31 @@ public class ReviewControllerV1 {
     ) {
         List<ReviewDto> reviews = reviewServiceV1.getMyReviewsByShop(userDetails.getUser(), shopId);
         return ApiResponse.ok(reviews);
+    }
+
+    /**
+     * 리뷰를 수정합니다.
+     *
+     * <p>
+     * 특정 리뷰 ID와 사용자 정보를 기반으로 리뷰를 수정합니다.
+     * {@link UpdateReviewRequest}에 포함된 필드만 부분적으로 업데이트되며,
+     * 수정된 리뷰 정보는 {@link ReviewDto} 형태로 반환됩니다.
+     * </p>
+     *
+     * @param reviewId 수정할 리뷰 ID
+     * @param updateRequest 리뷰 수정 요청 DTO
+     * @param userDetails 인증된 사용자 정보({@link UserDetailsImpl})
+     * @return 수정된 리뷰 정보를 포함한 {@link ApiResponse} 객체
+     * @throws IllegalStateException 리뷰 작성자가 아닌 사용자가 수정 요청을 한 경우
+     * @throws IllegalArgumentException 존재하지 않는 리뷰 ID가 전달된 경우
+     */
+    @PatchMapping("/{reviewId}")
+    public ResponseEntity<ApiResponse<ReviewDto>> updateReview(
+            @PathVariable String reviewId,
+            @Valid @RequestBody UpdateReviewRequest updateRequest,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        ReviewDto updatedReview = reviewServiceV1.updateReview(userDetails.getUser(), reviewId, updateRequest);
+        return ApiResponse.ok(updatedReview);
     }
 }

--- a/src/main/java/com/sparta/bapzip/review/presentation/controller/ReviewControllerV1.java
+++ b/src/main/java/com/sparta/bapzip/review/presentation/controller/ReviewControllerV1.java
@@ -1,4 +1,50 @@
 package com.sparta.bapzip.review.presentation.controller;
 
+import com.sparta.bapzip.global.response.ApiResponse;
+import com.sparta.bapzip.review.application.ReviewServiceV1;
+import com.sparta.bapzip.review.application.dto.request.CreateReviewRequest;
+import com.sparta.bapzip.review.presentation.dto.response.ReviewCreateResponse;
+import com.sparta.bapzip.user.domain.entity.UserDetailsImpl;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Review 관련 API를 처리하는 컨트롤러 (v1)
+ * <p>
+ * 리뷰 작성, 조회 등 리뷰 관련 요청을 처리합니다.
+ * 현재는 리뷰 생성 API만 제공됩니다.
+ * </p>
+ * @version 1.0
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/reviews")
 public class ReviewControllerV1 {
+
+    private final ReviewServiceV1 reviewServiceV1;
+
+    /**
+     * 새로운 리뷰를 작성합니다.
+     * <p>
+     * 사용자의 인증 정보와 요청 DTO를 받아 리뷰를 생성하고,
+     * 생성된 리뷰 정보를 포함한 {@link ReviewCreateResponse}를 반환합니다.
+     * </p>
+     *
+     * @param createReviewRequest 리뷰 작성에 필요한 정보(점수, 내용, 주문/가게 ID 등)를 담은 DTO
+     * @param userDetails 인증된 사용자 정보({@link UserDetailsImpl})
+     * @return 생성된 리뷰 정보를 포함한 {@link ApiResponse} 객체, HTTP 상태 코드 201(CREATED)
+     * @throws IllegalStateException 이미 해당 주문에 대한 리뷰가 존재하는 경우
+     * @throws IllegalArgumentException 존재하지 않는 주문 또는 가게 ID가 전달된 경우
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<ReviewCreateResponse>> createReview(
+            @Valid @RequestBody CreateReviewRequest createReviewRequest,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        ReviewCreateResponse response = reviewServiceV1.createReview(userDetails.getUser(), createReviewRequest);
+        return ApiResponse.created(response);
+    }
 }

--- a/src/main/java/com/sparta/bapzip/review/presentation/controller/ReviewControllerV1.java
+++ b/src/main/java/com/sparta/bapzip/review/presentation/controller/ReviewControllerV1.java
@@ -2,6 +2,7 @@ package com.sparta.bapzip.review.presentation.controller;
 
 import com.sparta.bapzip.global.response.ApiResponse;
 import com.sparta.bapzip.review.application.ReviewServiceV1;
+import com.sparta.bapzip.review.application.dto.ReviewDto;
 import com.sparta.bapzip.review.application.dto.request.CreateReviewRequest;
 import com.sparta.bapzip.review.presentation.dto.response.ReviewCreateResponse;
 import com.sparta.bapzip.user.domain.entity.UserDetailsImpl;
@@ -10,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * Review 관련 API를 처리하는 컨트롤러 (v1)
@@ -46,5 +49,45 @@ public class ReviewControllerV1 {
     ) {
         ReviewCreateResponse response = reviewServiceV1.createReview(userDetails.getUser(), createReviewRequest);
         return ApiResponse.created(response);
+    }
+
+    /**
+     * 특정 가게에 작성된 모든 리뷰를 조회합니다.
+     *
+     * @param shopId 조회할 가게의 ID
+     * @return 해당 가게의 리뷰 리스트
+     */
+    @GetMapping("/{shopId}")
+    public ResponseEntity<ApiResponse<List<ReviewDto>>> getReviewsByShop(@PathVariable String shopId) {
+        List<ReviewDto> reviews = reviewServiceV1.getReviewsByShop(shopId);
+        return ApiResponse.ok(reviews);
+    }
+
+    /**
+     * 인증된 사용자가 작성한 모든 리뷰를 조회합니다.
+     *
+     * @param userDetails 인증된 사용자 정보
+     * @return 사용자가 작성한 리뷰 리스트
+     */
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<List<ReviewDto>>> getMyReviews(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<ReviewDto> reviews = reviewServiceV1.getMyReviews(userDetails.getUser());
+        return ApiResponse.ok(reviews);
+    }
+
+    /**
+     * 인증된 사용자가 작성한 특정 가게 리뷰를 조회합니다.
+     *
+     * @param shopId 조회할 가게의 ID
+     * @param userDetails 인증된 사용자 정보
+     * @return 사용자가 작성한 해당 가게 리뷰 리스트
+     */
+    @GetMapping("/me/{shopId}")
+    public ResponseEntity<ApiResponse<List<ReviewDto>>> getMyReviewsByShop(
+            @PathVariable String shopId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        List<ReviewDto> reviews = reviewServiceV1.getMyReviewsByShop(userDetails.getUser(), shopId);
+        return ApiResponse.ok(reviews);
     }
 }

--- a/src/main/java/com/sparta/bapzip/review/presentation/dto/request/RequestDto.java
+++ b/src/main/java/com/sparta/bapzip/review/presentation/dto/request/RequestDto.java
@@ -1,4 +1,0 @@
-package com.sparta.bapzip.review.presentation.dto.request;
-
-public class RequestDto {
-}

--- a/src/main/java/com/sparta/bapzip/review/presentation/dto/response/ResponseDto.java
+++ b/src/main/java/com/sparta/bapzip/review/presentation/dto/response/ResponseDto.java
@@ -1,4 +1,0 @@
-package com.sparta.bapzip.review.presentation.dto.response;
-
-public class ResponseDto {
-}

--- a/src/main/java/com/sparta/bapzip/review/presentation/dto/response/ReviewCreateResponse.java
+++ b/src/main/java/com/sparta/bapzip/review/presentation/dto/response/ReviewCreateResponse.java
@@ -1,0 +1,54 @@
+package com.sparta.bapzip.review.presentation.dto.response;
+
+import com.sparta.bapzip.review.domain.entity.ReviewEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+/**
+ * 리뷰 생성 후 반환되는 응답 DTO
+ * <p>
+ * 클라이언트에게 리뷰 생성 결과를 전달하기 위해 사용됩니다.
+ * 리뷰 ID, 평점, 내용, 관련 가게/사용자/주문 ID 정보를 포함합니다.
+ * </p>
+ * @version 1.0
+ */
+@Getter
+@AllArgsConstructor
+public class ReviewCreateResponse {
+    /** 리뷰 고유 ID */
+    private UUID id;
+
+    /** 리뷰 평점 */
+    private int score;
+
+    /** 리뷰 내용 */
+    private String content;
+
+    /** 리뷰가 작성된 가게 ID */
+    private UUID shopId;
+
+    /** 리뷰를 작성한 사용자 ID */
+    private Long userId;
+
+    /** 리뷰와 연결된 주문 ID */
+    private UUID orderId;
+
+    /**
+     * ReviewEntity를 기반으로 ReviewCreateResponse DTO를 생성
+     *
+     * @param review ReviewEntity 객체
+     * @return ReviewCreateResponse 생성된 DTO
+     */
+    public static ReviewCreateResponse from(ReviewEntity review) {
+        return new ReviewCreateResponse(
+                review.getId(),
+                review.getScore(),
+                review.getContent(),
+                review.getShop().getId(),
+                review.getUser().getId(),
+                review.getOrder().getId()
+        );
+    }
+}


### PR DESCRIPTION
## 📒 Issue Number
closed #89

## 📒 Description
사용자가 작성한 리뷰를 삭제할 수 있는 기능을 구현했습니다
본인 리뷰만 삭제 가능하도록 인증 및 권한 체크 로직을 추가했습니다.
Soft delete 정책을 적용하여 DB에서는 삭제되지 않고 isDeleted 플래그로 상태를 관리합니다.
삭제된 리뷰는 조회 목록에서 제외됩니다.
존재하지 않는 리뷰에 대한 요청 시 예외를 반환하도록 처리했습니다.

주요 작업 내역
DELETE /reviews/{reviewId} API 엔드포인트 생성
ReviewServiceV1에 삭제 로직 구현
본인 인증 및 권한 검증 로직 추가
Soft delete 처리(markDeleted) 적용
ReviewNotFoundException, UnauthorizedReviewAccessException 예외 처리
삭제 성공 시 204 No Content 응답 반환

## 📒 Test Result
<img width="1396" height="892" alt="image" src="https://github.com/user-attachments/assets/9ec672f4-bb53-4653-ba5b-38db4d5b24f8" />


## 📒 To Reviewer
