### PR TITLE
test: 메뉴 도메인/서비스 단위 테스트 추가

### DIFF
--- a/src/main/java/com/sparta/bapzip/menu/application/MenuServiceV1.java
+++ b/src/main/java/com/sparta/bapzip/menu/application/MenuServiceV1.java
@@ -67,15 +67,9 @@ public class MenuServiceV1 {
         // 해당 가게 모든 메뉴 조회
         List<MenuEntity> menus = menuRepository.findAllByShopIdAndIsDeletedFalse(shopId);
 
-        // 메뉴 리스트 -> MenuItemDto 리스트로 변환
+        // 메뉴 리스트
         List<MenuListByShopResponse.MenuItemDto> menuItems = menus.stream()
-                .map(menu -> new MenuListByShopResponse.MenuItemDto(
-                        menu.getId(),
-                        menu.getName(),
-                        menu.getContent(),
-                        menu.getPrice(),
-                        menu.getStatus()
-                ))
+                .map(MenuListByShopResponse.MenuItemDto::from)
                 .toList();
 
         return new MenuListByShopResponse(shop.getId(), shop.getName(), menuItems);

--- a/src/main/java/com/sparta/bapzip/menu/presentation/controller/MenuControllerV1.java
+++ b/src/main/java/com/sparta/bapzip/menu/presentation/controller/MenuControllerV1.java
@@ -70,19 +70,19 @@ public class MenuControllerV1 {
 
     /**
      * 가게 별 메뉴 조회
+     * v1/menus?shopId=
      */
-    @GetMapping("/shops/{shopId}")
-    public ResponseEntity<ApiResponse<MenuListByShopResponse>> getMenusByShop(@PathVariable UUID shopId){
+    @GetMapping
+    public ResponseEntity<ApiResponse<MenuListByShopResponse>> getMenusByShop(@RequestParam UUID shopId){
         MenuListByShopResponse menuListByShop = menuService.getMenusByShop(shopId);
         return ApiResponse.ok(menuListByShop);
     }
 
     /**
      * 메뉴 전체 조회 - MANAGER, MASTER (관리자용)
-     * todo: Security Config @EnableMethodSecurity(prePostEnabled = true) 추가 시 활성화 => PreAuthorize
      */
     @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
-    @GetMapping
+    @GetMapping("/admin")
     public ResponseEntity<ApiResponse<List<MenuAdminResponse>>> getAllMenus(){
         List<MenuAdminResponse> menuList = menuService.getAllMenus();
         return ApiResponse.ok(menuList);

--- a/src/main/java/com/sparta/bapzip/menu/presentation/dto/response/MenuListByShopResponse.java
+++ b/src/main/java/com/sparta/bapzip/menu/presentation/dto/response/MenuListByShopResponse.java
@@ -1,5 +1,6 @@
 package com.sparta.bapzip.menu.presentation.dto.response;
 
+import com.sparta.bapzip.menu.domain.entity.MenuEntity;
 import com.sparta.bapzip.menu.domain.enums.MenuStatus;
 
 import java.util.List;
@@ -21,5 +22,15 @@ public record MenuListByShopResponse(
             String content,
             int price,
             MenuStatus status
-    ) {}
+    ) {
+        public static MenuItemDto from(MenuEntity menu) {
+            return new MenuItemDto(
+                    menu.getId(),
+                    menu.getName(),
+                    menu.getContent(),
+                    menu.getPrice(),
+                    menu.getStatus()
+            );
+        }
+    }
 }

--- a/src/test/java/com/sparta/bapzip/menu/application/MenuServiceV1Test.java
+++ b/src/test/java/com/sparta/bapzip/menu/application/MenuServiceV1Test.java
@@ -1,0 +1,420 @@
+package com.sparta.bapzip.menu.application;
+
+import com.sparta.bapzip.global.exception.ErrorCode;
+import com.sparta.bapzip.global.exception.GlobalException;
+import com.sparta.bapzip.menu.application.dto.request.MenuCreateRequest;
+import com.sparta.bapzip.menu.application.dto.request.MenuStatusUpdateRequest;
+import com.sparta.bapzip.menu.application.dto.request.MenuUpdateRequest;
+import com.sparta.bapzip.menu.application.exception.MenuNotFoundException;
+import com.sparta.bapzip.menu.domain.entity.MenuEntity;
+import com.sparta.bapzip.menu.domain.enums.MenuStatus;
+import com.sparta.bapzip.menu.domain.repository.MenuRepository;
+import com.sparta.bapzip.menu.presentation.dto.response.MenuCreateResponse;
+import com.sparta.bapzip.menu.presentation.dto.response.MenuDetailResponse;
+import com.sparta.bapzip.menu.presentation.dto.response.MenuListByShopResponse;
+import com.sparta.bapzip.menu.presentation.dto.response.MenuSearchResponse;
+import com.sparta.bapzip.shop.application.ShopServiceV1;
+import com.sparta.bapzip.shop.application.exception.ShopNotFoundException;
+import com.sparta.bapzip.shop.application.exception.UnauthorizedShopAccessException;
+import com.sparta.bapzip.shop.domain.entity.ShopEntity;
+import com.sparta.bapzip.user.domain.entity.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MenuServiceV1 단위 테스트")
+class MenuServiceV1Test {
+
+    @Mock
+    private MenuRepository menuRepository;
+
+    @Mock
+    private ShopServiceV1 shopServiceV1;
+
+    @InjectMocks
+    private MenuServiceV1 menuServiceV1;
+
+    // data
+    private ShopEntity testShop;
+    private MenuEntity testMenu;
+    private Long ownerId;
+    private UUID shopId;
+    private UUID menuId;
+
+    @BeforeEach
+    void setUp() {
+        // test data
+        ownerId = 1L;
+        shopId = UUID.randomUUID();
+        menuId = UUID.randomUUID();
+
+        UserEntity testUser = UserEntity.builder()
+                .id(ownerId)
+                .build();
+
+        testShop = ShopEntity.builder()
+                .id(shopId)
+                .name("TestShop")
+                .owner(testUser)
+                .build();
+
+        testMenu = MenuEntity.builder()
+                .id(menuId)
+                .shop(testShop)
+                .name("테스트 메뉴")
+                .price(10000)
+                .content("맛있는 메뉴입니다.")
+                .status(MenuStatus.AVAILABLE)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("메뉴 생성 테스트")
+    class CreateMenuTests {
+
+        @Test
+        @DisplayName("성공: 메뉴 생성 성공")
+        void createMenu_success() {
+
+            // given
+            MenuCreateRequest request = new MenuCreateRequest("새 메뉴 이름", "새 메뉴", 12000, shopId);
+            given(shopServiceV1.getShopById(request.shopId())).willReturn(testShop);
+            willDoNothing().given(shopServiceV1).validateShopOwner(testShop.getId(), ownerId);
+            given(menuRepository.save(any(MenuEntity.class))).willReturn(testMenu);
+
+            // when
+            MenuCreateResponse response = menuServiceV1.createMenu(request, ownerId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.id()).isEqualTo(testMenu.getId());
+            assertThat(response.name()).isEqualTo(testMenu.getName());
+            assertThat(response.content()).isEqualTo(testMenu.getContent());
+            assertThat(response.price()).isEqualTo(testMenu.getPrice());
+            assertThat(response.shopId()).isEqualTo(testShop.getId());
+
+        }
+
+        @Test
+        @DisplayName("실패: 가게 Owner 아님")
+        void createMenu_fail_notOwner() {
+
+            // given
+            MenuCreateRequest request = new MenuCreateRequest("새 메뉴 이름", "새 메뉴", 12000, shopId);
+            Long nonOwnerId = 2L;
+
+            given(shopServiceV1.getShopById(request.shopId())).willReturn(testShop);
+
+            willThrow(new UnauthorizedShopAccessException(ErrorCode.UNAUTHORIZED_SHOP_ACCESS))
+                    .given(shopServiceV1).validateShopOwner(testShop.getId(), nonOwnerId);
+
+            // when & then
+            assertThrows(UnauthorizedShopAccessException.class, () -> {
+                menuServiceV1.createMenu(request, nonOwnerId);
+            });
+
+            verify(menuRepository, never()).save(any(MenuEntity.class)); // 호출 non 검증
+        }
+    }
+
+
+    @Nested
+    @DisplayName("메뉴 상세 조회 테스트")
+    class GetMenuDetailsTests {
+
+        @Test
+        @DisplayName("성공: 상세 조회 성공")
+        void getMenuDetails_success() {
+
+            // given
+            given(menuRepository.findByIdAndIsDeletedFalse(menuId)).willReturn(Optional.of(testMenu));
+
+            // when
+            MenuDetailResponse response = menuServiceV1.getMenuDetail(menuId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.id()).isEqualTo(testMenu.getId());
+            assertThat(response.name()).isEqualTo(testMenu.getName());
+            assertThat(response.content()).isEqualTo(testMenu.getContent());
+            assertThat(response.price()).isEqualTo(testMenu.getPrice());
+            assertThat(response.shopId()).isEqualTo(testShop.getId());
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 메뉴")
+        void getMenuDetails_fail() {
+
+            // given
+            given(menuRepository.findByIdAndIsDeletedFalse(menuId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThrows(MenuNotFoundException.class, () -> {
+                menuServiceV1.getMenuDetail(menuId);
+            });
+        }
+    }
+
+
+    @Nested
+    @DisplayName("가게별 메뉴 목록 조회 테스트")
+    class GetMenusByShopTests {
+
+        @Test
+        @DisplayName("성공: 조회 성공")
+        void getMenusByShop_success() {
+
+            // given
+            given(shopServiceV1.getShopById(shopId)).willReturn(testShop);
+            given(menuRepository.findAllByShopIdAndIsDeletedFalse(shopId)).willReturn(List.of(testMenu));
+
+            // when
+            MenuListByShopResponse response = menuServiceV1.getMenusByShop(shopId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.shopName()).isEqualTo(testShop.getName());
+            assertThat(response.menus()).hasSize(1); // 1개
+            assertThat(response.menus().get(0).name()).isEqualTo(testMenu.getName());
+            assertThat(response.menus().get(0).price()).isEqualTo(testMenu.getPrice());
+            assertThat(response.menus().get(0).id()).isEqualTo(testMenu.getId());
+            assertThat(response.menus().get(0).status()).isEqualTo(testMenu.getStatus());
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 가게")
+        void getMenusByShop_fail_shopNotFound() {
+
+            // given
+            UUID nonExistShopId = UUID.randomUUID();
+            given(shopServiceV1.getShopById(nonExistShopId)).willThrow(new ShopNotFoundException(ErrorCode.SHOP_NOT_FOUND));
+
+            // when & then
+            assertThrows(ShopNotFoundException.class, () -> {
+                menuServiceV1.getMenusByShop(nonExistShopId);
+            });
+        }
+    }
+
+
+    @Nested
+    @DisplayName("메뉴 이름 기반 검색(페이징) 테스트")
+    class SearchMenusTests {
+
+        @Test
+        @DisplayName("성공: 메뉴 검색 완료")
+        void searchMenus_success() {
+
+            // given = default 값 + price
+            String keyword = "테스트";
+            Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "price"));
+            Page<MenuEntity> mockedPage = new PageImpl<>(List.of(testMenu), pageable, 1);
+
+            given(menuRepository.findByNameContainingAndIsDeletedFalse(eq(keyword), any(Pageable.class)))
+                    .willReturn(mockedPage);
+
+            // when
+            Page<MenuSearchResponse> result = menuServiceV1.searchMenus(keyword, 1, 10, "price", false);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getTotalElements()).isEqualTo(1);
+            assertThat(result.getContent().get(0).name()).isEqualTo(testMenu.getName());
+
+            verify(menuRepository).findByNameContainingAndIsDeletedFalse(eq(keyword), argThat(p ->
+                    p.getPageNumber() == 0 &&
+                            p.getPageSize() == 10 &&
+                            p.getSort().getOrderFor("price").getDirection().isDescending()
+            ));
+        }
+
+        @Test
+        @DisplayName("성공: 유효하지 않은 size 값 입력 시 기본값(10)으로 조회")
+        void searchMenus_withInvalidSize_shouldDefaultTo10() {
+
+            // given
+            String keyword = "테스트";
+            int invalidSize = 25;
+
+            Page<MenuEntity> mockedPage = new PageImpl<>(List.of(testMenu));
+            given(menuRepository.findByNameContainingAndIsDeletedFalse(eq(keyword), any(Pageable.class)))
+                    .willReturn(mockedPage);
+
+            // when
+            menuServiceV1.searchMenus(keyword, 1, invalidSize, "createdAt", false);
+
+            // then -> 10 검증
+            verify(menuRepository).findByNameContainingAndIsDeletedFalse(anyString(), argThat(p -> p.getPageSize() == 10));
+        }
+    }
+
+
+    @Nested
+    @DisplayName("메뉴 정보 수정 테스트(PATCH)")
+    class UpdateMenuTests {
+
+        @Test
+        @DisplayName("성공: 모든 정보 수정")
+        void updateMenu_success_fullUpdate() {
+
+            MenuUpdateRequest request = new MenuUpdateRequest("새 이름", "새 내용", 5000);
+            given(menuRepository.findByIdAndIsDeletedFalse(menuId)).willReturn(Optional.of(testMenu));
+            willDoNothing().given(shopServiceV1).validateShopOwner(testShop.getId(), ownerId);
+
+            // when
+            MenuDetailResponse response = menuServiceV1.updateMenu(menuId, request, ownerId);
+
+            // then
+            assertThat(response.name()).isEqualTo("새 이름");
+            assertThat(response.content()).isEqualTo("새 내용");
+            assertThat(response.price()).isEqualTo(5000);
+        }
+
+        @Test
+        @DisplayName("성공: 부분 수정")
+        void updateMenu_success_partialUpdate() {
+
+            MenuStatus originalStatus = testMenu.getStatus();
+            String originalContent = testMenu.getContent();
+            Integer originalPrice = testMenu.getPrice();
+
+            // 이름만 변경
+            MenuUpdateRequest request = new MenuUpdateRequest("이름만 변경", null, null);
+            given(menuRepository.findByIdAndIsDeletedFalse(menuId)).willReturn(Optional.of(testMenu));
+            willDoNothing().given(shopServiceV1).validateShopOwner(testShop.getId(), ownerId);
+
+            // when
+            MenuDetailResponse response = menuServiceV1.updateMenu(menuId, request, ownerId);
+
+            // then
+            assertThat(response.name()).isEqualTo("이름만 변경");
+            assertThat(response.status()).isEqualTo(originalStatus);
+            assertThat(response.content()).isEqualTo(originalContent);
+            assertThat(response.price()).isEqualTo(originalPrice);
+        }
+
+
+        @Test
+        @DisplayName("실패: 가게 Owner 아님")
+        void updateMenu_fail_notOwner() {
+
+            // given
+            Long nonOwnerId = 2L;
+            MenuUpdateRequest request = new MenuUpdateRequest("메뉴 이름 수정 시도",null, null);
+            given(menuRepository.findByIdAndIsDeletedFalse(menuId)).willReturn(Optional.of(testMenu));
+            willThrow(new UnauthorizedShopAccessException(ErrorCode.UNAUTHORIZED_SHOP_ACCESS))
+                    .given(shopServiceV1).validateShopOwner(testShop.getId(), nonOwnerId);
+
+            // when & then
+            assertThrows(UnauthorizedShopAccessException.class, () -> {
+                menuServiceV1.updateMenu(menuId, request, nonOwnerId);
+            });
+        }
+    }
+
+
+    @Nested
+    @DisplayName("메뉴 상태 수정 테스트")
+    class UpdateMenuStatusTests {
+
+        @Test
+        @DisplayName("성공: 메뉴 상태 수정")
+        void updateMenuStatus_success() {
+
+            // given
+            MenuStatusUpdateRequest request = new MenuStatusUpdateRequest(MenuStatus.SOLD_OUT.name());
+            given(menuRepository.findByIdAndIsDeletedFalse(menuId)).willReturn(Optional.of(testMenu));
+            willDoNothing().given(shopServiceV1).validateShopOwner(testShop.getId(), ownerId);
+
+            // when
+            MenuDetailResponse response = menuServiceV1.updateMenuStatus(menuId, request, ownerId);
+
+            // then
+            assertThat(response.status()).isEqualTo(MenuStatus.SOLD_OUT);
+        }
+
+        @Test
+        @DisplayName("실패: 가게 Owner 아님")
+        void updateMenuStatus_fail_notOwner() {
+            // given
+            Long nonOwnerId = 2L;
+            MenuStatusUpdateRequest  request = new MenuStatusUpdateRequest(MenuStatus.SOLD_OUT.name());
+            given(menuRepository.findByIdAndIsDeletedFalse(menuId)).willReturn(Optional.of(testMenu));
+            willThrow(UnauthorizedShopAccessException.class)
+                    .given(shopServiceV1).validateShopOwner(testShop.getId(), nonOwnerId);
+
+            // when & then
+            assertThrows(UnauthorizedShopAccessException.class, () -> {
+                menuServiceV1.updateMenuStatus(menuId, request, nonOwnerId);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("메뉴 삭제(soft delete) 테스트")
+    class DeleteMenuTests {
+
+        @Test
+        @DisplayName("성공: 메뉴 삭제 성공(soft delete)")
+        void deleteMenu_success() {
+
+            // given
+            given(menuRepository.findByIdAndIsDeletedFalse(menuId)).willReturn(Optional.of(testMenu));
+            willDoNothing().given(shopServiceV1).validateShopOwner(testShop.getId(), ownerId);
+
+            // when
+            menuServiceV1.deleteMenu(menuId, ownerId);
+
+            // then
+            assertThat(testMenu.getIsDeleted()).isTrue();
+        }
+
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 메뉴")
+        void deleteMenu_fail_menuNotFound() {
+
+            // given
+            UUID nonExistMenuId = UUID.randomUUID();
+            given(menuRepository.findByIdAndIsDeletedFalse(nonExistMenuId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThrows(MenuNotFoundException.class, () -> {
+                menuServiceV1.deleteMenu(nonExistMenuId, ownerId);
+            });
+        }
+
+        @Test
+        @DisplayName("실패: 가게 Owner 아님")
+        void deleteMenu_fail_notOwner() {
+
+            // given
+            Long nonOwnerId = 2L;
+            given(menuRepository.findByIdAndIsDeletedFalse(menuId)).willReturn(Optional.of(testMenu));
+            willThrow(new GlobalException(ErrorCode.UNAUTHORIZED_SHOP_ACCESS))
+                    .given(shopServiceV1).validateShopOwner(testShop.getId(), nonOwnerId);
+
+            // when & then
+            assertThrows(GlobalException.class, () -> {
+                menuServiceV1.deleteMenu(menuId, nonOwnerId);
+            });
+        }
+    }
+
+}

--- a/src/test/java/com/sparta/bapzip/menu/domain/entity/MenuEntityTest.java
+++ b/src/test/java/com/sparta/bapzip/menu/domain/entity/MenuEntityTest.java
@@ -1,0 +1,230 @@
+package com.sparta.bapzip.menu.domain.entity;
+
+import com.sparta.bapzip.menu.application.dto.request.MenuCreateRequest;
+import com.sparta.bapzip.menu.domain.enums.MenuStatus;
+import com.sparta.bapzip.menu.domain.exception.InvalidMenuStatusException;
+import com.sparta.bapzip.menu.domain.exception.MenuAlreadyDeletedException;
+import com.sparta.bapzip.shop.domain.entity.ShopEntity;
+import com.sparta.bapzip.user.domain.entity.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+class MenuEntityTest {
+
+    private UserEntity owner;
+    private ShopEntity shop;
+
+    @BeforeEach
+    void setUp() {
+        owner = UserEntity.builder()
+                .id(1L)
+                .name("사장님")
+                .email("owner@test.com")
+                .build();
+
+        shop = ShopEntity.builder()
+                .id(UUID.randomUUID())
+                .name("테스트 가게")
+                .owner(owner)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("메뉴 생성 테스트")
+    class CreateMenuTest {
+
+        @Test
+        @DisplayName("메뉴 생성")
+        void createMenu_success() {
+
+            // given
+            MenuCreateRequest request = new MenuCreateRequest("비빔밥", "맛있는 한식", 15000, shop.getId());
+
+            // when
+            MenuEntity menu = MenuEntity.createMenu(request, shop);
+
+            // then
+            assertThat(menu.getName()).isEqualTo("비빔밥");
+            assertThat(menu.getContent()).isEqualTo("맛있는 한식");
+            assertThat(menu.getPrice()).isEqualTo(15000);
+            assertThat(menu.getStatus()).isEqualTo(MenuStatus.AVAILABLE); // 기본 값 확인
+            assertThat(menu.getShop()).isEqualTo(shop);
+            assertThat(menu.getShop().getOwner()).isEqualTo(owner);
+        }
+    }
+
+
+    /**
+     * 메뉴 정보 수정
+     */
+    @Nested
+    @DisplayName("메뉴 정보 수정 테스트(PATCH)")
+    class UpdateMenuInfoTest {
+
+        @Test
+        @DisplayName("메뉴 정보 전체 수정")
+        void updateFields() {
+
+            // given
+            MenuEntity menu = MenuEntity.builder()
+                    .name("초기이름")
+                    .content("초기내용")
+                    .price(10000)
+                    .shop(shop)
+                    .build();
+
+            // when
+            menu.updateName("수정이름");
+            menu.updateContent("수정내용");
+            menu.updatePrice(5000);
+
+            // then
+            assertThat(menu.getName()).isEqualTo("수정이름");
+            assertThat(menu.getContent()).isEqualTo("수정내용");
+            assertThat(menu.getPrice()).isEqualTo(5000);
+        }
+
+
+        @Test
+        @DisplayName("메뉴 이름만 수정")
+        void updateName_only() {
+
+            // given
+            MenuEntity menu = MenuEntity.builder()
+                    .name("초기이름")
+                    .content("초기내용")
+                    .price(10000)
+                    .shop(shop)
+                    .build();
+
+            // when
+            menu.updateName("수정이름");
+
+            // then
+            assertThat(menu.getName()).isEqualTo("수정이름"); // 이름만 수정
+            assertThat(menu.getContent()).isEqualTo("초기내용");
+            assertThat(menu.getPrice()).isEqualTo(10000);
+        }
+
+        @Test
+        @DisplayName("메뉴 내용만 수정")
+        void updateContent_only() {
+            MenuEntity menu = MenuEntity.builder()
+                    .name("초기이름")
+                    .content("초기내용")
+                    .price(10000)
+                    .shop(shop)
+                    .build();
+
+            menu.updateContent("수정내용");
+
+            assertThat(menu.getName()).isEqualTo("초기이름");
+            assertThat(menu.getContent()).isEqualTo("수정내용");
+            assertThat(menu.getPrice()).isEqualTo(10000);
+        }
+
+        @Test
+        @DisplayName("메뉴 가격만 수정")
+        void updatePrice_only() {
+            MenuEntity menu = MenuEntity.builder()
+                    .name("초기이름")
+                    .content("초기내용")
+                    .price(10000)
+                    .shop(shop)
+                    .build();
+
+            menu.updatePrice(5000);
+
+            assertThat(menu.getName()).isEqualTo("초기이름");
+            assertThat(menu.getContent()).isEqualTo("초기내용");
+            assertThat(menu.getPrice()).isEqualTo(5000);
+        }
+    }
+
+
+    /**
+     * 메뉴 상태(AVAILABLE, SOLD_OUT) 수정
+     */
+    @Nested
+    @DisplayName("메뉴 상태 관련 테스트")
+    class UpdateMenuStatusTests {
+
+        private MenuEntity menu;
+
+        @BeforeEach
+        void initMenu() {
+            menu = MenuEntity.builder()
+                    .name("라면")
+                    .content("매운 라면")
+                    .price(5000)
+                    .status(MenuStatus.AVAILABLE)
+                    .shop(shop)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("메뉴 상태 변경")
+        void updateStatus() {
+            menu.updateStatus(MenuStatus.SOLD_OUT);
+            assertThat(menu.getStatus()).isEqualTo(MenuStatus.SOLD_OUT);
+        }
+
+        @Test
+        @DisplayName("메뉴 상태 값 예외 발생")
+        void invalidMenuStatus() {
+            String invalidValue = "TEST"; // enum에 없는 값
+
+            assertThatThrownBy(() -> MenuStatus.from(invalidValue))
+                    .isInstanceOf(InvalidMenuStatusException.class);
+        }
+    }
+
+
+    @Nested
+    @DisplayName("메뉴 삭제 테스트")
+    class DeleteMenuTests{
+
+        @Test
+        @DisplayName("메뉴 삭제 성공")
+        void deleteMenu_success() {
+
+            // given
+            MenuEntity menu = MenuEntity.builder()
+                    .name("김치찌개")
+                    .content("칼칼함")
+                    .price(7000)
+                    .build();
+
+            // when
+            menu.deleteMenu(1L);
+
+            // then
+            assertThat(menu.getIsDeleted()).isTrue();
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 경우 예외 발생")
+        void deleteMenu_alreadyDeleted() {
+
+            // given
+            MenuEntity menu = MenuEntity.builder()
+                    .name("된장찌개")
+                    .content("국물 진함")
+                    .price(7000)
+                    .build();
+
+            menu.markDeleted(1L);
+
+            // when & then
+            assertThatThrownBy(() -> menu.deleteMenu(1L))
+                    .isInstanceOf(MenuAlreadyDeletedException.class);
+        }
+    }
+}


### PR DESCRIPTION
## 📒 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #78 

## 📒 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 메뉴 도메인/서비스 단위 테스트 추가
- 가게 별 메뉴 조회, 메뉴 전체 조회(관리자) url 매핑 변경

## 📒 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="376" height="585" alt="스크린샷 2025-10-15 162749" src="https://github.com/user-attachments/assets/d20bef8a-a747-4ae4-8876-5aa608e9fe2c" />
<img width="390" height="386" alt="스크린샷 2025-10-15 162812" src="https://github.com/user-attachments/assets/a6e8ab8c-9dc3-4c34-ab08-f0e023f64ba7" />


## 📒 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->

